### PR TITLE
feat: expose connection data

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,29 @@ connection.connect(ProviderType.INJECTED, ChainId.ROPSTEN)
 connection.disconnect()
 ```
 
+### .getConnectionData()
+
+Returns the data used for the last successfull [.connect()](#connect) call. It's used by [.tryPreviousConnection](#trypreviousconnection) to determine which connection to use. Check [ConnectionData](#ConnectionData) for more info on the returned type
+
+**Definition**
+
+```typescript
+getConnectionData(): ConnectionData | undefined
+```
+
+**Usage**
+
+```typescript
+const connection = new ConnectionManager(new Storage())
+connection.connect(ProviderType.INJECTED, ChainId.ROPSTEN)
+
+// (...)
+
+const connectionData = connection.getConnectionData() // => connectionData is ConnectionData
+```
+
+
+
 ### .getAvialableProviders()
 
 Returns the providers available for connection. If for example no `window` object is found, `ProviderType.INJECTED` will not be returned on the list
@@ -198,6 +221,15 @@ export type ConnectionResponse = {
   provider: Provider
   chainId: ChainId
   account: null | string
+}
+```
+
+### ConnectionData
+
+```typescript
+export type ConnectionData = {
+  providerType: ProviderType
+  chainId: ChainId
 }
 ```
 

--- a/src/ConnectionManager.ts
+++ b/src/ConnectionManager.ts
@@ -29,7 +29,7 @@ export class ConnectionManager {
     chainId: ChainId = ChainId.MAINNET
   ): Promise<ConnectionResponse> {
     this.setConnectionData(providerType, chainId)
-    this.connector = this.getConnector(providerType, chainId)
+    this.connector = this.buildConnector(providerType, chainId)
 
     const {
       provider,
@@ -86,12 +86,12 @@ export class ConnectionManager {
     providerType: ProviderType,
     chainId: ChainId = ChainId.MAINNET
   ): Promise<Provider> {
-    const connector = this.getConnector(providerType, chainId)
+    const connector = this.buildConnector(providerType, chainId)
     const provider = await connector.getProvider()
     return this.toProvider(provider)
   }
 
-  getConnector(
+  buildConnector(
     providerType: ProviderType,
     chainId: ChainId
   ): AbstractConnector {
@@ -107,7 +107,7 @@ export class ConnectionManager {
     }
   }
 
-  private getConnectionData(): ConnectionData | undefined {
+  getConnectionData(): ConnectionData | undefined {
     const { storageKey } = getConfiguration()
     const connectionData = this.storage.get(storageKey)
     return connectionData ? JSON.parse(connectionData) : undefined

--- a/test/ConnectionManager.spec.ts
+++ b/test/ConnectionManager.spec.ts
@@ -38,7 +38,7 @@ describe('ConnectionManager', () => {
   describe('#connect', () => {
     it('should set the connector', async () => {
       const stubConnector = new StubConnector()
-      sinon.stub(connectionManager, 'getConnector').returns(stubConnector)
+      sinon.stub(connectionManager, 'buildConnector').returns(stubConnector)
 
       expect(connectionManager.connector).to.eq(undefined)
       await connectionManager.connect(ProviderType.INJECTED)
@@ -48,7 +48,7 @@ describe('ConnectionManager', () => {
     it('should activate the connector', async () => {
       const stubConnector = new StubConnector()
       const getConnectorStub = sinon
-        .stub(connectionManager, 'getConnector')
+        .stub(connectionManager, 'buildConnector')
         .returns(stubConnector)
       const activateStub = sinon.stub(stubConnector, 'activate').callThrough()
 
@@ -60,7 +60,7 @@ describe('ConnectionManager', () => {
 
     it('should return the connection data', async () => {
       const stubConnector = new StubConnector()
-      sinon.stub(connectionManager, 'getConnector').returns(stubConnector)
+      sinon.stub(connectionManager, 'buildConnector').returns(stubConnector)
 
       const result = await connectionManager.connect(
         ProviderType.INJECTED,
@@ -82,7 +82,7 @@ describe('ConnectionManager', () => {
 
     it('should not patch the provider with the request method if it already exists', async () => {
       const stubConnector = new StubConnector()
-      sinon.stub(connectionManager, 'getConnector').returns(stubConnector)
+      sinon.stub(connectionManager, 'buildConnector').returns(stubConnector)
 
       const result = await connectionManager.connect(
         ProviderType.INJECTED,
@@ -104,7 +104,7 @@ describe('ConnectionManager', () => {
     it('should store the last provider and chain', async () => {
       const stubConnector = new StubConnector()
       const configuration = getConfiguration()
-      sinon.stub(connectionManager, 'getConnector').returns(stubConnector)
+      sinon.stub(connectionManager, 'buildConnector').returns(stubConnector)
 
       await connectionManager.connect(ProviderType.INJECTED, ChainId.KOVAN)
 
@@ -128,7 +128,7 @@ describe('ConnectionManager', () => {
     it('should connect to the last supplied provider', async () => {
       const stubConnector = new StubConnector()
       const getConnectorStub = sinon
-        .stub(connectionManager, 'getConnector')
+        .stub(connectionManager, 'buildConnector')
         .returns(stubConnector)
 
       await connectionManager.connect(ProviderType.FORTMATIC)
@@ -151,6 +151,24 @@ describe('ConnectionManager', () => {
           chainId: ChainId.MAINNET
         })
       )
+    })
+  })
+
+  describe('#getConnectionData', () => {
+    it('should return the data used on the last successful connection', async () => {
+      const stubConnector = new StubConnector()
+      sinon.stub(connectionManager, 'buildConnector').returns(stubConnector)
+
+      await connectionManager.connect(ProviderType.INJECTED, ChainId.KOVAN)
+
+      expect(connectionManager.getConnectionData()).to.deep.eq({
+        providerType: ProviderType.INJECTED,
+        chainId: ChainId.KOVAN
+      })
+    })
+
+    it('should return undefined if no connection happneed', () => {
+      expect(connectionManager.getConnectionData()).to.eq(undefined)
     })
   })
 
@@ -214,7 +232,7 @@ describe('ConnectionManager', () => {
         const provider = { send: () => {} }
 
         const getConnectorStub = sinon
-          .stub(connectionManager, 'getConnector')
+          .stub(connectionManager, 'buildConnector')
           .returns(stubConnector)
         const getProviderStub = sinon
           .stub(stubConnector, 'getProvider')
@@ -276,16 +294,16 @@ describe('ConnectionManager', () => {
     })
   })
 
-  describe('#getConnector', () => {
+  describe('#buildConnector', () => {
     it('should throw if an invalid provider type is supplied', () => {
       const providerType = 'Invalid Provider Type' as any
       expect(() =>
-        connectionManager.getConnector(providerType, ChainId.MAINNET)
+        connectionManager.buildConnector(providerType, ChainId.MAINNET)
       ).to.throw(`Invalid provider ${providerType}`)
     })
 
     it('should return an instance of FortmaticConnector for the supplied chain', () => {
-      const connector = connectionManager.getConnector(
+      const connector = connectionManager.buildConnector(
         ProviderType.FORTMATIC,
         ChainId.KOVAN
       )
@@ -294,7 +312,7 @@ describe('ConnectionManager', () => {
     })
 
     it('should return an instance of InjectedConnector for the supplied chain', () => {
-      const connector = connectionManager.getConnector(
+      const connector = connectionManager.buildConnector(
         ProviderType.INJECTED,
         ChainId.KOVAN
       )
@@ -303,7 +321,7 @@ describe('ConnectionManager', () => {
     })
 
     it('should return an instance of WalletConnectConnector for the supplied chain', () => {
-      const connector = connectionManager.getConnector(
+      const connector = connectionManager.buildConnector(
         ProviderType.WALLET_CONNECT,
         ChainId.KOVAN
       )


### PR DESCRIPTION
# Important

I'm not sure about this implementation, I have another option which is exposing each property individually like this:

```ts
export class ConnectionManager {
  connector?: AbstractConnector

  constructor(public storage: Storage) {}

  get providerType() {
    const connectionData = this.getConnectionData()
    return connectionData ? connectionData.providerType : undefined
  }

  get chainId() {
    const connectionData = this.getConnectionData()
    return connectionData ? connectionData.chainId : undefined
  }
```

What do you guys think?