### PR TITLE
fix: Trigger 3.1.1 release

### DIFF
--- a/src/connectors/WalletLinkConnector.ts
+++ b/src/connectors/WalletLinkConnector.ts
@@ -4,6 +4,7 @@ import { RPC_URLS } from './NetworkConnector'
 
 const APP_NAME = 'Decentraland'
 
+// Coinbase connector to connect a wallet with the Coinbase mobile wallet
 export class WalletLinkConnector extends BaseWalletLinkConnector {
   constructor(chainId: ChainId) {
     super({


### PR DESCRIPTION
3.1.0 commit did not have semantic release tag due to being merged instead of squashed.