### PR TITLE
fix: @dcl/schemas imports

### DIFF
--- a/src/connectors/InjectedConnector.ts
+++ b/src/connectors/InjectedConnector.ts
@@ -1,4 +1,4 @@
-import { ChainId } from '@dcl/schemas'
+import { ChainId } from '@dcl/schemas/dist/dapps/chain-id'
 import { InjectedConnector as BaseInjectedConnector } from '@web3-react/injected-connector'
 
 export class InjectedConnector extends BaseInjectedConnector {

--- a/src/connectors/NetworkConnector.ts
+++ b/src/connectors/NetworkConnector.ts
@@ -1,4 +1,4 @@
-import { ChainId } from '@dcl/schemas'
+import { ChainId } from '@dcl/schemas/dist/dapps/chain-id'
 import { NetworkConnector as BaseNetworkConnector } from '@web3-react/network-connector'
 
 export const RPC_URLS = Object.freeze({

--- a/src/connectors/WalletLinkConnector.ts
+++ b/src/connectors/WalletLinkConnector.ts
@@ -1,4 +1,4 @@
-import { ChainId } from '@dcl/schemas'
+import { ChainId } from '@dcl/schemas/dist/dapps/chain-id'
 import { WalletLinkConnector as BaseWalletLinkConnector } from '@web3-react/walletlink-connector'
 import { RPC_URLS } from './NetworkConnector'
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,5 +1,3 @@
-
-
 import { ChainId } from '@dcl/schemas/dist/dapps/chain-id'
 import { ConnectorUpdate } from '@web3-react/types'
 import { AbstractConnector } from '../src/connectors/AbstractConnector'

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,4 +1,6 @@
-import { ChainId } from '@dcl/schemas'
+
+
+import { ChainId } from '@dcl/schemas/dist/dapps/chain-id'
 import { ConnectorUpdate } from '@web3-react/types'
 import { AbstractConnector } from '../src/connectors/AbstractConnector'
 import { Storage } from '../src/storage'


### PR DESCRIPTION
## Context

some browsers are getting the following error when we import directly from `@dcl/schemas`

```
Uncaught SyntaxError: Invalid flags supplied to RegExp constructor 'u'
```

## Solution

This PR replace all directs imports from `@dcl/schemas` in favor of each specific file to prevent this error and also reduce the bundle size of the library