### PR TITLE
chore: change npm install to npm ci

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: 16.x
       - name: install
-        run: npm install
+        run: npm ci
       - name: build
         run: npm run build
       #- name: print diff if failed

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: 16.x
       - name: install
-        run: npm ci
+        run: npm ci --legacy-peer-deps
       - name: build
         run: npm run build
       #- name: print diff if failed


### PR DESCRIPTION
Change `npm install` to `npm ci` and use legacy peer deps