### PR TITLE
fix: Support Fortmatic Goerli through new class

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -49,15 +49,14 @@ export function getRpcUrls(providerType: ProviderType) {
   let project = ''
 
   switch (providerType) {
-    case ProviderType.FORTMATIC:
-      project = 'fortmatic'
-      break
     case ProviderType.WALLET_CONNECT:
       project = 'walletconnect'
       break
     case ProviderType.WALLET_LINK:
       project = 'walletlink'
       break
+    case ProviderType.FORTMATIC:
+      project = 'fortmatic'
     default:
       break
   }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -57,6 +57,7 @@ export function getRpcUrls(providerType: ProviderType) {
       break
     case ProviderType.FORTMATIC:
       project = 'fortmatic'
+      break
     default:
       break
   }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -14,7 +14,7 @@ const configuration = Object.freeze({
       [ChainId.ETHEREUM_KOVAN]: 'pk_test_5B728BEFE5C10911',
       [ChainId.ETHEREUM_GOERLI]: 'pk_test_5B728BEFE5C10911'
     },
-    urls: getRpcUrls(ProviderType.NETWORK)
+    urls: getRpcUrls(ProviderType.FORTMATIC)
   },
 
   [ProviderType.NETWORK]: {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -13,7 +13,8 @@ const configuration = Object.freeze({
       [ChainId.ETHEREUM_RINKEBY]: 'pk_test_5B728BEFE5C10911',
       [ChainId.ETHEREUM_KOVAN]: 'pk_test_5B728BEFE5C10911',
       [ChainId.ETHEREUM_GOERLI]: 'pk_test_5B728BEFE5C10911'
-    }
+    },
+    urls: getRpcUrls(ProviderType.NETWORK)
   },
 
   [ProviderType.NETWORK]: {
@@ -48,6 +49,9 @@ export function getRpcUrls(providerType: ProviderType) {
   let project = ''
 
   switch (providerType) {
+    case ProviderType.FORTMATIC:
+      project = 'fortmatic'
+      break
     case ProviderType.WALLET_CONNECT:
       project = 'walletconnect'
       break

--- a/src/connectors/FortmaticConnector.ts
+++ b/src/connectors/FortmaticConnector.ts
@@ -1,20 +1,72 @@
-import { ChainId } from '@dcl/schemas/dist/dapps/chain-id'
-import { ProviderType } from '@dcl/schemas/dist/dapps/provider-type'
-import { FortmaticConnector as BaseFortmaticConnector } from '@web3-react/fortmatic-connector'
-import { getConfiguration } from '../configuration'
+import { ConnectorUpdate } from '@web3-react/types'
+import { AbstractConnector } from '@web3-react/abstract-connector'
+import { ChainId, ProviderType } from '@dcl/schemas'
+import { getConfiguration } from 'src/configuration'
 
-export class FortmaticConnector extends BaseFortmaticConnector {
-  apiKeys: Record<number, string>
+export class FortmaticConnector extends AbstractConnector {
+  private readonly apiKey: string
+  private readonly chainId: number
+  private readonly rpcUrl: string
+  public fortmatic: any
 
   constructor(chainId: ChainId) {
-    const { apiKeys } = getConfiguration()[ProviderType.FORTMATIC]
+    const fortmaticConfiguration = getConfiguration()[ProviderType.FORTMATIC]
+    const supportedChainIds = Object.keys(
+      fortmaticConfiguration.apiKeys
+    ).map(key => Number(key))
+    if (!supportedChainIds.includes(chainId)) {
+      throw new Error(`Invariant error: Unsupported chainId ${chainId}`)
+    }
+    super({ supportedChainIds })
 
-    super({ chainId, apiKey: apiKeys[chainId] })
-    this.apiKeys = apiKeys
+    this.apiKey = fortmaticConfiguration.apiKeys[chainId]
+    this.chainId = chainId
+    this.rpcUrl = fortmaticConfiguration.apiKeys[chainId]
   }
 
-  public async getApiKey(): Promise<string> {
-    const chainId = await this.getChainId()
-    return this.apiKeys[chainId]
+  public async activate(): Promise<ConnectorUpdate> {
+    if (!this.fortmatic) {
+      // @ts-ignore
+      const { default: Fortmatic } = await import('fortmatic')
+      this.fortmatic = new Fortmatic(this.apiKey, {
+        rpcUrl: this.rpcUrl,
+        chainId: this.chainId
+      })
+    }
+
+    const account = await this.fortmatic
+      .getProvider()
+      .enable()
+      .then((accounts: string[]): string => accounts[0])
+
+    return {
+      provider: this.fortmatic.getProvider(),
+      chainId: this.chainId,
+      account
+    }
+  }
+
+  public async getProvider(): Promise<any> {
+    return this.fortmatic.getProvider()
+  }
+
+  public async getChainId(): Promise<number | string> {
+    return this.chainId
+  }
+
+  public async getAccount(): Promise<null | string> {
+    return this.fortmatic
+      .getProvider()
+      .send('eth_accounts')
+      .then((accounts: string[]): string => accounts[0])
+  }
+
+  public deactivate() {
+    this.close()
+  }
+
+  public async close() {
+    await this.fortmatic.user.logout()
+    this.emitDeactivate()
   }
 }

--- a/src/connectors/FortmaticConnector.ts
+++ b/src/connectors/FortmaticConnector.ts
@@ -1,13 +1,13 @@
 import { ConnectorUpdate } from '@web3-react/types'
 import { AbstractConnector } from '@web3-react/abstract-connector'
 import { ChainId, ProviderType } from '@dcl/schemas'
-import { getConfiguration } from 'src/configuration'
+import { getConfiguration } from '../configuration'
 
 export class FortmaticConnector extends AbstractConnector {
   private readonly apiKey: string
   private readonly chainId: number
   private readonly rpcUrl: string
-  public fortmatic: any
+  private fortmatic: any
 
   constructor(chainId: ChainId) {
     const fortmaticConfiguration = getConfiguration()[ProviderType.FORTMATIC]
@@ -46,6 +46,10 @@ export class FortmaticConnector extends AbstractConnector {
     }
   }
 
+  public getApiKey(): string {
+    return this.apiKey
+  }
+
   public async getProvider(): Promise<any> {
     return this.fortmatic.getProvider()
   }
@@ -62,7 +66,7 @@ export class FortmaticConnector extends AbstractConnector {
   }
 
   public deactivate() {
-    this.close()
+    return this.close()
   }
 
   public async close() {

--- a/src/connectors/FortmaticConnector.ts
+++ b/src/connectors/FortmaticConnector.ts
@@ -65,9 +65,8 @@ export class FortmaticConnector extends AbstractConnector {
       .then((accounts: string[]): string => accounts[0])
   }
 
-  public deactivate() {
-    return this.close()
-  }
+  // tslint:disable-next-line
+  public deactivate() {}
 
   public async close() {
     await this.fortmatic.user.logout()

--- a/src/connectors/FortmaticConnector.ts
+++ b/src/connectors/FortmaticConnector.ts
@@ -21,7 +21,7 @@ export class FortmaticConnector extends AbstractConnector {
 
     this.apiKey = fortmaticConfiguration.apiKeys[chainId]
     this.chainId = chainId
-    this.rpcUrl = fortmaticConfiguration.apiKeys[chainId]
+    this.rpcUrl = fortmaticConfiguration.urls[chainId]
   }
 
   public async activate(): Promise<ConnectorUpdate> {

--- a/test/configuration.spec.ts
+++ b/test/configuration.spec.ts
@@ -14,6 +14,15 @@ describe('#getConfiguration', () => {
           '4': 'pk_test_5B728BEFE5C10911',
           '5': 'pk_test_5B728BEFE5C10911',
           '42': 'pk_test_5B728BEFE5C10911'
+        },
+        urls: {
+          '1': 'https://rpc.decentraland.org/mainnet?project=fortmatic',
+          '3': 'https://rpc.decentraland.org/ropsten?project=fortmatic',
+          '4': 'https://rpc.decentraland.org/rinkeby?project=fortmatic',
+          '5': 'https://rpc.decentraland.org/goerli?project=fortmatic',
+          '42': 'https://rpc.decentraland.org/kovan?project=fortmatic',
+          '137': 'https://rpc.decentraland.org/polygon?project=fortmatic',
+          '80001': 'https://rpc.decentraland.org/mumbai?project=fortmatic'
         }
       },
       network: {


### PR DESCRIPTION
The `web3-react` package removed the support for the `Fortmatic` wallet long time ago. We're using the 6th version of the package which has the class that supports Fortmatic but it does not have support for Goerli, mainly because it doesn't allow its usage through a check in the class.
This PR recreates the class adding support for Goerli.