### PR TITLE
fix: propagate chainId to WalletConnect

### DIFF
--- a/src/ConnectionManager.ts
+++ b/src/ConnectionManager.ts
@@ -23,7 +23,7 @@ import './declarations'
 export class ConnectionManager {
   connector?: AbstractConnector
 
-  constructor(public storage: Storage) {}
+  constructor(public storage: Storage) { }
 
   async connect(
     providerType: ProviderType,
@@ -132,7 +132,7 @@ export class ConnectionManager {
       case ProviderType.FORTMATIC:
         return new FortmaticConnector(chainId)
       case ProviderType.WALLET_CONNECT:
-        return new WalletConnectConnector()
+        return new WalletConnectConnector(chainId)
       case ProviderType.WALLET_LINK:
         return new WalletLinkConnector(chainId)
       case ProviderType.NETWORK:

--- a/src/ConnectionManager.ts
+++ b/src/ConnectionManager.ts
@@ -23,7 +23,7 @@ import './declarations'
 export class ConnectionManager {
   connector?: AbstractConnector
 
-  constructor(public storage: Storage) { }
+  constructor(public storage: Storage) {}
 
   async connect(
     providerType: ProviderType,

--- a/src/connectors/WalletConnectConnector.ts
+++ b/src/connectors/WalletConnectConnector.ts
@@ -53,8 +53,13 @@ export class BaseWalletConnectConnector extends AbstractConnector {
       const WalletConnectProvider = await import(
         '@walletconnect/web3-provider'
       ).then(m => m?.default ?? m)
-      const chainId = this.config.supportedChainIds && this.config.supportedChainIds[0] || ChainId.ETHEREUM_MAINNET
-      this.walletConnectProvider = new WalletConnectProvider({ ...this.config, chainId })
+      const chainId =
+        (this.config.supportedChainIds && this.config.supportedChainIds[0]) ||
+        ChainId.ETHEREUM_MAINNET
+      this.walletConnectProvider = new WalletConnectProvider({
+        ...this.config,
+        chainId
+      })
     }
 
     let account = ''

--- a/src/connectors/WalletConnectConnector.ts
+++ b/src/connectors/WalletConnectConnector.ts
@@ -11,6 +11,7 @@ export const URI_AVAILABLE = 'URI_AVAILABLE'
 export interface WalletConnectConnectorArguments
   extends IWalletConnectProviderOptions {
   supportedChainIds?: number[]
+  defaultChainId?: number
 }
 
 export class UserRejectedRequestError extends Error {
@@ -53,12 +54,9 @@ export class BaseWalletConnectConnector extends AbstractConnector {
       const WalletConnectProvider = await import(
         '@walletconnect/web3-provider'
       ).then(m => m?.default ?? m)
-      const chainId =
-        (this.config.supportedChainIds && this.config.supportedChainIds[0]) ||
-        ChainId.ETHEREUM_MAINNET
       this.walletConnectProvider = new WalletConnectProvider({
         ...this.config,
-        chainId
+        chainId: this.config.defaultChainId || ChainId.ETHEREUM_MAINNET
       })
     }
 
@@ -160,13 +158,13 @@ export class WalletConnectConnector extends BaseWalletConnectConnector {
     pollingInterval: number
   }
 
-  constructor(chainId: ChainId = ChainId.ETHEREUM_MAINNET) {
+  constructor(defaultChainId: ChainId = ChainId.ETHEREUM_MAINNET) {
     const { urls } = getConfiguration()[ProviderType.WALLET_CONNECT]
     const params = {
       rpc: urls,
       qrcode: true,
       pollingInterval: 150000,
-      supportedChainIds: [chainId]
+      defaultChainId
     }
 
     super(params)

--- a/src/connectors/WalletConnectConnector.ts
+++ b/src/connectors/WalletConnectConnector.ts
@@ -1,3 +1,4 @@
+import { ChainId } from '@dcl/schemas/dist/dapps/chain-id'
 import { ProviderType } from '@dcl/schemas/dist/dapps/provider-type'
 import { ConnectorUpdate } from '@web3-react/types'
 import { AbstractConnector } from '@web3-react/abstract-connector'
@@ -52,7 +53,8 @@ export class BaseWalletConnectConnector extends AbstractConnector {
       const WalletConnectProvider = await import(
         '@walletconnect/web3-provider'
       ).then(m => m?.default ?? m)
-      this.walletConnectProvider = new WalletConnectProvider(this.config)
+      const chainId = this.config.supportedChainIds && this.config.supportedChainIds[0] || ChainId.ETHEREUM_MAINNET
+      this.walletConnectProvider = new WalletConnectProvider({ ...this.config, chainId })
     }
 
     let account = ''
@@ -153,12 +155,13 @@ export class WalletConnectConnector extends BaseWalletConnectConnector {
     pollingInterval: number
   }
 
-  constructor() {
+  constructor(chainId: ChainId = ChainId.ETHEREUM_MAINNET) {
     const { urls } = getConfiguration()[ProviderType.WALLET_CONNECT]
     const params = {
       rpc: urls,
       qrcode: true,
-      pollingInterval: 150000
+      pollingInterval: 150000,
+      supportedChainIds: [chainId]
     }
 
     super(params)


### PR DESCRIPTION
This PR propagates `chainId` prop to the walletConnectProvider preventing errors when a restricted wallet tries to connect with a network different from MAINNET

![image](https://user-images.githubusercontent.com/208789/226938240-51637f39-1e22-452f-9adf-8ac8a48c97b1.png)
