### PR TITLE
fix: Update send async

### DIFF
--- a/src/ConnectionManager.ts
+++ b/src/ConnectionManager.ts
@@ -45,7 +45,7 @@ export class ConnectionManager {
     this.setConnectionData(providerType, chainId)
 
     return {
-      provider: ProviderAdapter.adapt(provider, providerType),
+      provider: ProviderAdapter.adapt(provider),
       providerType,
       account: account || '',
       chainId
@@ -127,7 +127,7 @@ export class ConnectionManager {
   ): Promise<Provider> {
     const connector = this.buildConnector(providerType, chainId)
     const provider = await connector.getProvider()
-    return ProviderAdapter.adapt(provider, providerType)
+    return ProviderAdapter.adapt(provider)
   }
 
   buildConnector(

--- a/src/ProviderAdapter.ts
+++ b/src/ProviderAdapter.ts
@@ -51,12 +51,10 @@ export class ProviderAdapter {
 
   request = async ({ method, params }: Arguments) => {
     if (this.isModernProvider()) {
-      const value: any = await (this.provider as Provider).request({
+      return (this.provider as Provider).request({
         method,
         params
       })
-
-      return value
     }
 
     return this.send(method, params)


### PR DESCRIPTION
sendAsync returns the standard JSON-RPC response. However WC2 now returns the same thing as request, which is just the response without the extra things.
I order to handle this, only on sendAsync the result is being wrapped in case it is not wrapped.