### PR TITLE
feat: Add get wallet name function to connection manager

### DIFF
--- a/src/ConnectionManager.ts
+++ b/src/ConnectionManager.ts
@@ -121,6 +121,19 @@ export class ConnectionManager {
     return this.connector.getProvider()
   }
 
+  /**
+   * Obtain the name of the underlying wallet providing the connection.
+   * Will only return a value if the provider is a WalletConnectV2Connector that has an ongoing session.
+   * TODO: Enhance it to return the name of the wallet for other providers as well if possible.
+   */
+  getWalletName = (): string | undefined => {
+    if (this.connector instanceof WalletConnectV2Connector) {
+      return this.connector.getWalletName()
+    }
+
+    return undefined
+  }
+
   async createProvider(
     providerType: ProviderType,
     chainId: ChainId = ChainId.ETHEREUM_MAINNET

--- a/src/connectors/WalletConnectV2Connector.ts
+++ b/src/connectors/WalletConnectV2Connector.ts
@@ -102,6 +102,10 @@ export class WalletConnectV2Connector extends AbstractConnector {
     return this.provider.accounts[0]
   }
 
+  getWalletName = (): string | undefined => {
+    return this.provider?.session?.peer.metadata.name
+  }
+
   deactivate = (): void => {
     if (!this.provider) {
       return


### PR DESCRIPTION
Useful to obtain the wallet used to connect through WalletConnect.