### PR TITLE
fix: Use local var provider

### DIFF
--- a/src/connectors/WalletConnectV2Connector.ts
+++ b/src/connectors/WalletConnectV2Connector.ts
@@ -82,7 +82,7 @@ export class WalletConnectV2Connector extends AbstractConnector {
     return {
       chainId: provider.chainId,
       account: accounts[0],
-      provider: this.provider
+      provider
     }
   }
 


### PR DESCRIPTION
It was annoying me that for chainId I was using the closure provider but passing the class provider in the return. (They are the same)