### PR TITLE
feat: Redirect all whitelisted read methods to the RPC

### DIFF
--- a/src/providers/AuthServerProvider.ts
+++ b/src/providers/AuthServerProvider.ts
@@ -276,11 +276,20 @@ export class AuthServerProvider {
      */
     if (
       [
+        'eth_getTransactionReceipt',
+        'eth_estimateGas',
         'eth_call',
         'eth_getBalance',
-        'eth_getCode',
+        'eth_getStorageAt',
+        'eth_blockNumber',
+        'eth_gasPrice',
+        'eth_protocolVersion',
+        'net_version',
+        'web3_sha3',
+        'web3_clientVersion',
         'eth_getTransactionCount',
-        'eth_getStorageAt'
+        'eth_getBlockByNumber',
+        'eth_getCode'
       ].includes(method)
     ) {
       const provider = new ethers.JsonRpcProvider(


### PR DESCRIPTION
This PR adds all the [whitelisted methods](https://github.com/decentraland/unity-renderer/blob/308c4d4e9ceb8171ee04a2c6d49c8a906233d9a2/browser-interface/packages/lib/web3/EthereumService.ts#L26C1-L43C16) that don't require a signature to the RPC call list.