### PR TITLE
fix: Add a timeout to the injected wallets when are locked

### DIFF
--- a/src/ConnectionManager.ts
+++ b/src/ConnectionManager.ts
@@ -46,7 +46,8 @@ export class ConnectionManager {
     connector.on(ConnectorEvent.Deactivate, this.handleWeb3ReactDeactivate)
     let { provider, account }: ConnectorUpdate = {}
     try {
-      ;({ provider, account } = await connector.activate())
+      const update: ConnectorUpdate = await connector.activate()
+      ;({ provider, account } = update)
     } catch (error) {
       throw new ErrorUnlockingWallet()
     }

--- a/src/ConnectionManager.ts
+++ b/src/ConnectionManager.ts
@@ -16,7 +16,8 @@ import {
   ConnectionData,
   ConnectionResponse,
   Provider,
-  ClosableConnector
+  ClosableConnector,
+  ErrorUnlockingWallet
 } from './types'
 import { getConfiguration } from './configuration'
 import { ProviderAdapter } from './ProviderAdapter'
@@ -43,8 +44,12 @@ export class ConnectionManager {
 
     const connector = this.buildConnector(providerType, chainIdToConnect)
     connector.on(ConnectorEvent.Deactivate, this.handleWeb3ReactDeactivate)
-    const { provider, account }: ConnectorUpdate = await connector.activate()
-
+    let { provider, account }: ConnectorUpdate = {}
+    try {
+      ;({ provider, account } = await connector.activate())
+    } catch (error) {
+      throw new ErrorUnlockingWallet()
+    }
     if (providerType === ProviderType.MAGIC) {
       connector.on(ConnectorEvent.Update, ({ chainId }) => {
         if (chainId) {

--- a/src/ConnectionManager.ts
+++ b/src/ConnectionManager.ts
@@ -46,8 +46,8 @@ export class ConnectionManager {
     connector.on(ConnectorEvent.Deactivate, this.handleWeb3ReactDeactivate)
     let { provider, account }: ConnectorUpdate = {}
     try {
-      const update: ConnectorUpdate = await connector.activate()
-      ;({ provider, account } = update)
+      const _connector: ConnectorUpdate = await connector.activate()
+      ;({ provider, account } = _connector)
     } catch (error) {
       throw new ErrorUnlockingWallet()
     }

--- a/src/ConnectionManager.ts
+++ b/src/ConnectionManager.ts
@@ -1,6 +1,6 @@
 import { ChainId } from '@dcl/schemas/dist/dapps/chain-id'
 import { ProviderType } from '@dcl/schemas/dist/dapps/provider-type'
-import { ConnectorEvent, ConnectorUpdate } from '@web3-react/types'
+import { ConnectorEvent } from '@web3-react/types'
 import {
   AbstractConnector,
   InjectedConnector,
@@ -16,8 +16,7 @@ import {
   ConnectionData,
   ConnectionResponse,
   Provider,
-  ClosableConnector,
-  ErrorUnlockingWallet
+  ClosableConnector
 } from './types'
 import { getConfiguration } from './configuration'
 import { ProviderAdapter } from './ProviderAdapter'
@@ -42,43 +41,43 @@ export class ConnectionManager {
       }
     }
 
-    const connector = this.buildConnector(providerType, chainIdToConnect)
-    connector.on(ConnectorEvent.Deactivate, this.handleWeb3ReactDeactivate)
-    let { provider, account }: ConnectorUpdate = {}
     try {
-      const _connector: ConnectorUpdate = await connector.activate()
-      ;({ provider, account } = _connector)
+      const connector = this.buildConnector(providerType, chainIdToConnect)
+      connector.on(ConnectorEvent.Deactivate, this.handleWeb3ReactDeactivate)
+
+      const { provider, account } = await connector.activate()
+
+      if (providerType === ProviderType.MAGIC) {
+        connector.on(ConnectorEvent.Update, ({ chainId }) => {
+          if (chainId) {
+            this.setConnectionData(providerType, chainId)
+          }
+        })
+      }
+
+      let chainId = chainIdToConnect
+
+      // We need to return the correct current chain id for the injected providers
+      if (providerType === ProviderType.INJECTED) {
+        const currentChainIdHex = (await provider.request({
+          method: 'eth_chainId'
+        })) as string
+        chainId = currentChainIdHex
+          ? (parseInt(currentChainIdHex, 16) as ChainId)
+          : chainId
+      }
+
+      this.connector = connector
+      this.setConnectionData(providerType, chainId)
+
+      return {
+        provider: ProviderAdapter.adapt(provider),
+        providerType,
+        account: account || '',
+        chainId
+      }
     } catch (error) {
-      throw new ErrorUnlockingWallet()
-    }
-    if (providerType === ProviderType.MAGIC) {
-      connector.on(ConnectorEvent.Update, ({ chainId }) => {
-        if (chainId) {
-          this.setConnectionData(providerType, chainId)
-        }
-      })
-    }
-
-    let chainId = chainIdToConnect
-
-    // We need to return the correct current chain id for the injected providers
-    if (providerType === ProviderType.INJECTED) {
-      const currentChainIdHex = (await provider.request({
-        method: 'eth_chainId'
-      })) as string
-      chainId = currentChainIdHex
-        ? (parseInt(currentChainIdHex, 16) as ChainId)
-        : chainId
-    }
-
-    this.connector = connector
-    this.setConnectionData(providerType, chainId)
-
-    return {
-      provider: ProviderAdapter.adapt(provider),
-      providerType,
-      account: account || '',
-      chainId
+      throw error
     }
   }
 

--- a/src/connectors/InjectedConnector.ts
+++ b/src/connectors/InjectedConnector.ts
@@ -13,19 +13,15 @@ export class InjectedConnector extends BaseInjectedConnector {
   }
 
   async activate(): Promise<ConnectorUpdate> {
-    return new Promise((resolve, reject) => {
-      // Set a timeout to reject the promise if the wallet is not unlocked
-      const timeout = setTimeout(() => {
+    // Set a timeout to reject the promise if the wallet is not unlocked
+    const timeoutPromise = new Promise<ConnectorUpdate>((_, reject) => {
+      setTimeout(() => {
         reject(new ErrorUnlockingWallet())
       }, UNLOCK_WALLET_TIMEOUT)
-
-      super
-        .activate()
-        .then(resolve)
-        .catch(reject)
-        .finally(() => {
-          clearTimeout(timeout)
-        })
     })
+
+    const activatePromise = super.activate()
+
+    return Promise.race([activatePromise, timeoutPromise])
   }
 }

--- a/src/connectors/InjectedConnector.ts
+++ b/src/connectors/InjectedConnector.ts
@@ -1,10 +1,30 @@
 import { ChainId } from '@dcl/schemas/dist/dapps/chain-id'
 import { InjectedConnector as BaseInjectedConnector } from '@web3-react/injected-connector'
+import { ConnectorUpdate } from '@web3-react/types'
+
+const UNLOCK_WALLET_TIMEOUT = 60 * 1000 // 60 seconds
 
 export class InjectedConnector extends BaseInjectedConnector {
   constructor(chainId: ChainId) {
     super({
       supportedChainIds: [chainId]
+    })
+  }
+
+  activate = async (): Promise<ConnectorUpdate> => {
+    return new Promise((resolve, reject) => {
+      // Set a timeout to reject the promise if the wallet is not unlocked
+      const timeout = setTimeout(() => {
+        reject(new Error('Timeout unlocking the wallet'))
+      }, UNLOCK_WALLET_TIMEOUT)
+
+      super
+        .activate()
+        .then(resolve)
+        .catch(reject)
+        .finally(() => {
+          clearTimeout(timeout)
+        })
     })
   }
 }

--- a/src/connectors/InjectedConnector.ts
+++ b/src/connectors/InjectedConnector.ts
@@ -1,6 +1,7 @@
 import { ChainId } from '@dcl/schemas/dist/dapps/chain-id'
 import { InjectedConnector as BaseInjectedConnector } from '@web3-react/injected-connector'
 import { ConnectorUpdate } from '@web3-react/types'
+import { ErrorUnlockingWallet } from '../types'
 
 const UNLOCK_WALLET_TIMEOUT = 60 * 1000 // 60 seconds
 
@@ -11,11 +12,11 @@ export class InjectedConnector extends BaseInjectedConnector {
     })
   }
 
-  activate = async (): Promise<ConnectorUpdate> => {
+  async activate(): Promise<ConnectorUpdate> {
     return new Promise((resolve, reject) => {
       // Set a timeout to reject the promise if the wallet is not unlocked
       const timeout = setTimeout(() => {
-        reject(new Error('Timeout unlocking the wallet'))
+        reject(new ErrorUnlockingWallet())
       }, UNLOCK_WALLET_TIMEOUT)
 
       super

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,3 +59,11 @@ export type ConnectionResponse = {
 export interface ClosableConnector extends AbstractConnector {
   close: () => Promise<void>
 }
+
+export class ErrorUnlockingWallet extends Error {
+  constructor() {
+    super(
+      'There was an error unlocking your wallet. Please be sure your wallet is unlocked and try again.'
+    )
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,5 +65,6 @@ export class ErrorUnlockingWallet extends Error {
     super(
       'There was an error unlocking your wallet. Please be sure your wallet is unlocked and try again.'
     )
+    this.name = 'ErrorUnlockingWallet'
   }
 }

--- a/test/ConnectionManager.spec.ts
+++ b/test/ConnectionManager.spec.ts
@@ -11,10 +11,11 @@ import {
   WalletLinkConnector
 } from '../src/connectors'
 import { LocalStorage } from '../src/storage'
-import { ClosableConnector } from '../src/types'
+import { ClosableConnector, ErrorUnlockingWallet } from '../src/types'
 import {
   StubClosableConnector,
   StubConnector,
+  StubLockedWalletConnector,
   StubStorage,
   getSendableProvider
 } from './utils'
@@ -160,6 +161,16 @@ describe('ConnectionManager', () => {
         })
       )
       expect(storage.get(configuration.storageKey)).to.eq(value)
+    })
+
+    describe('and the wallet is locked', () => {
+      it('should throw an error when activating the connector', async () => {
+        const stubConnector = new StubLockedWalletConnector()
+        sinon.stub(connectionManager, 'buildConnector').returns(stubConnector)
+        await expect(
+          connectionManager.connect(ProviderType.INJECTED)
+        ).to.be.rejectedWith(ErrorUnlockingWallet)
+      })
     })
   })
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -2,7 +2,7 @@ import { ChainId } from '@dcl/schemas/dist/dapps/chain-id'
 import { ConnectorUpdate } from '@web3-react/types'
 import { AbstractConnector } from '../src/connectors/AbstractConnector'
 import { Storage } from '../src/storage'
-import { Request } from '../src/types'
+import { ErrorUnlockingWallet, Request } from '../src/types'
 
 export class StubConnector extends AbstractConnector {
   public account: string | null = '0xdeadbeef'
@@ -54,6 +54,14 @@ export class StubConnector extends AbstractConnector {
 export class StubClosableConnector extends StubConnector {
   async close() {
     // no-op
+  }
+}
+
+export class StubLockedWalletConnector extends StubConnector {
+  async activate(): Promise<ConnectorUpdate> {
+    return new Promise((_resolve, reject) => {
+      reject(new ErrorUnlockingWallet())
+    })
   }
 }
 


### PR DESCRIPTION
This PR adds a timeout to the injected connector class to throw an error when the wallet keeps locked.