### PR TITLE
fix: Wallet connect stale session issues

### DIFF
--- a/src/connectors/WalletConnectV2Connector.ts
+++ b/src/connectors/WalletConnectV2Connector.ts
@@ -79,7 +79,10 @@ export class WalletConnectV2Connector extends AbstractConnector {
         // Namespace errors from @walletconnect/universal-provider's validateChain
         // when session has stale namespace data without matching rpcProviders
         message.includes('is not configured') ||
-        message.includes('cannot read properties')
+        message.includes('cannot read properties') ||
+        // UniversalProvider.getProvider() returns undefined for a stale session's namespace,
+        // causing "undefined is not an object" when setDefaultChain is called on it
+        message.includes('undefined is not an object')
       )
     }
     return false
@@ -196,6 +199,30 @@ export class WalletConnectV2Connector extends AbstractConnector {
   }
 
   /**
+   * Validates that a restored session is still alive on the WalletConnect relay
+   * by making a lightweight RPC call. Returns false if the session is stale.
+   */
+  private validateRestoredSession = async (appKit: AppKit): Promise<boolean> => {
+    try {
+      const walletProvider = appKit.getWalletProvider() as EIP1193Provider | undefined
+      if (!walletProvider) {
+        return false
+      }
+      // eth_chainId is a cheap, read-only call that doesn't require user interaction
+      await walletProvider.request({ method: 'eth_chainId' })
+      return true
+    } catch (error) {
+      if (WalletConnectV2Connector.isStaleSessionError(error)) {
+        return false
+      }
+      // Non-stale errors (e.g. network issues) — treat session as potentially valid
+      // to avoid unnecessarily forcing reconnection
+      console.warn('Error validating WalletConnect session:', error)
+      return true
+    }
+  }
+
+  /**
    * Opens the AppKit modal and waits for the user to connect.
    * Handles timeout, user cancellation, and stale session errors.
    */
@@ -276,7 +303,17 @@ export class WalletConnectV2Connector extends AbstractConnector {
     const existingAccount = appKit.getAccount()
     const isConnected = existingAccount?.status === 'connected' && existingAccount?.address
 
-    if (!isConnected) {
+    if (isConnected) {
+      // Session was restored from localStorage, but it may be stale on the relay.
+      // Validate with a lightweight RPC call before trusting it.
+      const isSessionAlive = await this.validateRestoredSession(appKit)
+      if (!isSessionAlive) {
+        console.warn('Restored WalletConnect session is stale, clearing and prompting reconnection...')
+        WalletConnectV2Connector.clearStorage()
+        await this.initAppKit()
+        await this.openModalAndWaitForConnection()
+      }
+    } else {
       await this.openModalAndWaitForConnection()
     }
 


### PR DESCRIPTION
### Why

Users are hitting two errors that share the same root cause:

- `No matching key. session topic doesn't exist`
- `undefined is not an object (evaluating 'this.getProvider(r).setDefaultChain')`

When a user returns to the app, AppKit restores session data from localStorage and reports `status === 'connected'`. The existing code trusts this and skips the connection modal, returning the provider directly. But the session may no longer exist on the WalletConnect relay — the relay evicts sessions after inactivity. The first RPC call then fails because the relay has no record of the session topic.

The `setDefaultChain` crash is a variant of the same problem: `UniversalProvider` tries to look up the chain-specific provider from its `rpcProviders` map, but that map was never populated because the stale session didn't fully initialize. So `this.getProvider(namespace)` returns `undefined` and calling `.setDefaultChain` on it throws.

The existing stale session handling in `activate()` and `openModalAndWaitForConnection()` couldn't catch this because `initAppKit()` only reads from localStorage — it never contacts the relay, so the error never surfaces there. And since the session appears connected, `openModalAndWaitForConnection()` is never called.

### How

**Proactive validation via `validateRestoredSession()`**: When `activate()` finds a restored session that reports as connected, it now makes a lightweight `eth_chainId` RPC call through the wallet provider before trusting it. This call goes through the relay and will fail immediately if the session topic no longer exists. If it fails with a stale session error, storage is cleared and the user is prompted to reconnect fresh. Non-stale errors (e.g. transient network issues) are treated optimistically to avoid forcing unnecessary reconnections.

**Extended `isStaleSessionError()` detection**: Added `'undefined is not an object'` to the set of recognized stale session error patterns. This acts as a safety net so that if the `setDefaultChain` crash surfaces through other code paths (like network switching after activation), the existing recovery logic can handle it rather than letting it propagate as an unhandled error.
