### PR TITLE
fix: Enable injected wallet detection in AppKit modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@dcl/schemas": "^22.1.0",
         "@magic-ext/oauth2": "15.3.2-canary.1040.22248562051.0",
         "@reown/appkit": "^1.8.15",
-        "@reown/appkit-adapter-ethers5": "^1.8.15",
+        "@reown/appkit-adapter-wagmi": "^1.8.19",
         "@web3-react/fortmatic-connector": "^6.1.6",
         "@web3-react/injected-connector": "^6.0.7",
         "@web3-react/network-connector": "^6.1.3",
@@ -1227,6 +1227,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@ethersproject/address": "^5.8.0",
         "@ethersproject/bignumber": "^5.8.0",
@@ -1254,6 +1255,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.8.0",
         "@ethersproject/bytes": "^5.8.0",
@@ -1279,6 +1281,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.8.0",
         "@ethersproject/bignumber": "^5.8.0",
@@ -1325,6 +1328,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.8.0"
       }
@@ -1344,6 +1348,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.8.0",
         "@ethersproject/properties": "^5.8.0"
@@ -1423,6 +1428,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@ethersproject/abi": "^5.8.0",
         "@ethersproject/abstract-provider": "^5.8.0",
@@ -1451,6 +1457,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.8.0",
         "@ethersproject/address": "^5.8.0",
@@ -1478,6 +1485,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.8.0",
         "@ethersproject/basex": "^5.8.0",
@@ -1508,6 +1516,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.8.0",
         "@ethersproject/address": "^5.8.0",
@@ -1575,6 +1584,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@ethersproject/logger": "^5.8.0"
       }
@@ -1594,6 +1604,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.8.0",
         "@ethersproject/sha2": "^5.8.0"
@@ -1633,6 +1644,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.8.0",
         "@ethersproject/abstract-signer": "^5.8.0",
@@ -1661,6 +1673,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1692,6 +1705,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.8.0",
         "@ethersproject/logger": "^5.8.0"
@@ -1715,28 +1729,6 @@
       "dependencies": {
         "@ethersproject/bytes": "^5.8.0",
         "@ethersproject/logger": "^5.8.0"
-      }
-    },
-    "node_modules/@ethersproject/sha2": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.8.0.tgz",
-      "integrity": "sha512-dDOUrXr9wF/YFltgTBYS0tKslPEKr6AekjqDW2dbn1L1xmjGR+9GiKu4ajxovnrDbwxAKdHjW8jNcwfz8PAz4A==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0",
-        "hash.js": "1.1.7"
       }
     },
     "node_modules/@ethersproject/signing-key": {
@@ -1778,6 +1770,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.8.0",
         "@ethersproject/bytes": "^5.8.0",
@@ -1802,6 +1795,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.8.0",
         "@ethersproject/constants": "^5.8.0",
@@ -1850,6 +1844,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.8.0",
         "@ethersproject/constants": "^5.8.0",
@@ -1871,6 +1866,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.8.0",
         "@ethersproject/abstract-signer": "^5.8.0",
@@ -1904,6 +1900,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@ethersproject/base64": "^5.8.0",
         "@ethersproject/bytes": "^5.8.0",
@@ -1927,6 +1924,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.8.0",
         "@ethersproject/hash": "^5.8.0",
@@ -3889,10 +3887,10 @@
         "@lit/react": "1.0.8"
       }
     },
-    "node_modules/@reown/appkit-adapter-ethers5": {
+    "node_modules/@reown/appkit-adapter-wagmi": {
       "version": "1.8.19",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-adapter-ethers5/-/appkit-adapter-ethers5-1.8.19.tgz",
-      "integrity": "sha512-Q45k6XCg2IdvKbkTlJVLJdkVkyje8NAvF+FkazSrtC0d4CXTOPfkR0tTsoW2GoB/L2nGgxEmniOMfWv5Rr9JvQ==",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-adapter-wagmi/-/appkit-adapter-wagmi-1.8.19.tgz",
+      "integrity": "sha512-KY2sbIXJDLlUVBAKdHBQ8KT8aQY67rWwW9aIz4XthRIt8WCjZQBEf4JGy/kd0LwRS78XSSpZcxDxEBarMPLpaA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@reown/appkit": "1.8.19",
@@ -3905,12 +3903,16 @@
         "@walletconnect/universal-provider": "2.23.7",
         "valtio": "2.1.7"
       },
+      "optionalDependencies": {
+        "@wagmi/connectors": ">=5.9.9"
+      },
       "peerDependencies": {
-        "@ethersproject/sha2": "5.8.0",
-        "ethers": ">=4.1 <6.0.0"
+        "@wagmi/core": ">=2.21.2",
+        "viem": ">=2.45.0",
+        "wagmi": ">=2.19.5"
       }
     },
-    "node_modules/@reown/appkit-adapter-ethers5/node_modules/@reown/appkit-pay": {
+    "node_modules/@reown/appkit-adapter-wagmi/node_modules/@reown/appkit-pay": {
       "version": "1.8.19",
       "resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.8.19.tgz",
       "integrity": "sha512-HO/tQT0TbTQO3eONxNNPJAOZAOzUiHvjM0Mty1rFFeRBH68auiqQxQi2YFNMs014gNkRN+cb84VYau7+MCC0fQ==",
@@ -3924,7 +3926,7 @@
         "valtio": "2.1.7"
       }
     },
-    "node_modules/@reown/appkit-adapter-ethers5/node_modules/@reown/appkit-polyfills": {
+    "node_modules/@reown/appkit-adapter-wagmi/node_modules/@reown/appkit-polyfills": {
       "version": "1.8.19",
       "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.8.19.tgz",
       "integrity": "sha512-PSoetRSuZg7f2YFPzdfs4BayQl51zcGqYr7frwOe6td0XEsspLrrVFn/zk5QFbFHZVsMdfRZ+TTunt84ozRdnQ==",
@@ -3933,7 +3935,7 @@
         "buffer": "6.0.3"
       }
     },
-    "node_modules/@reown/appkit-adapter-ethers5/node_modules/@reown/appkit-scaffold-ui": {
+    "node_modules/@reown/appkit-adapter-wagmi/node_modules/@reown/appkit-scaffold-ui": {
       "version": "1.8.19",
       "resolved": "https://registry.npmjs.org/@reown/appkit-scaffold-ui/-/appkit-scaffold-ui-1.8.19.tgz",
       "integrity": "sha512-Ak767x0VzeDIXb0wbzkl19kx6udw7vkb1EU0SAweG3iKc9BunW87Rfcd48/YimzMZycJaYmlbtfmqQQDYs6Few==",
@@ -3948,7 +3950,7 @@
         "lit": "3.3.0"
       }
     },
-    "node_modules/@reown/appkit-adapter-ethers5/node_modules/@reown/appkit-ui": {
+    "node_modules/@reown/appkit-adapter-wagmi/node_modules/@reown/appkit-ui": {
       "version": "1.8.19",
       "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.8.19.tgz",
       "integrity": "sha512-fCAwW8yyyC3JcgKLBPvCtYuDGC4H8anO7u4LTaAXGEzdcU5H+IrCgNFSPNK7NuTSmgXm1TnoYxPxRFKNiNwFdA==",
@@ -3962,7 +3964,7 @@
         "qrcode": "1.5.3"
       }
     },
-    "node_modules/@reown/appkit-adapter-ethers5/node_modules/@reown/appkit-wallet": {
+    "node_modules/@reown/appkit-adapter-wagmi/node_modules/@reown/appkit-wallet": {
       "version": "1.8.19",
       "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.8.19.tgz",
       "integrity": "sha512-NVdIKceUhkXYtsG32925ctmVn0QJFNyDlr+mWheMLCEZ/IUPn+6aA53vTVaSUquhyeFxUXtrCOh3ln6v1tup5w==",
@@ -3974,7 +3976,7 @@
         "zod": "3.22.4"
       }
     },
-    "node_modules/@reown/appkit-adapter-ethers5/node_modules/@walletconnect/core": {
+    "node_modules/@reown/appkit-adapter-wagmi/node_modules/@walletconnect/core": {
       "version": "2.23.7",
       "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.7.tgz",
       "integrity": "sha512-yTyymn9mFaDZkUfLfZ3E9VyaSDPeHAXlrPxQRmNx2zFsEt/25GmTU2A848aomimLxZnAG2jNLhxbJ8I0gyNV+w==",
@@ -4002,7 +4004,7 @@
         "node": ">=18.20.8"
       }
     },
-    "node_modules/@reown/appkit-adapter-ethers5/node_modules/@walletconnect/logger": {
+    "node_modules/@reown/appkit-adapter-wagmi/node_modules/@walletconnect/logger": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.2.tgz",
       "integrity": "sha512-7wR3wAwJTOmX4gbcUZcFMov8fjftY05+5cO/d4cpDD8wDzJ+cIlKdYOXaXfxHLSYeDazMXIsxMYjHYVDfkx+nA==",
@@ -4012,7 +4014,7 @@
         "pino": "10.0.0"
       }
     },
-    "node_modules/@reown/appkit-adapter-ethers5/node_modules/@walletconnect/sign-client": {
+    "node_modules/@reown/appkit-adapter-wagmi/node_modules/@walletconnect/sign-client": {
       "version": "2.23.7",
       "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.23.7.tgz",
       "integrity": "sha512-SX61lzb1bTl/LijlcHQttnoHPBzzoY5mW9ArR6qhFtDNDTS7yr2rcH7rCngxHlYeb4rAYcWLHgbiGSrdKxl/mg==",
@@ -4029,7 +4031,7 @@
         "events": "3.3.0"
       }
     },
-    "node_modules/@reown/appkit-adapter-ethers5/node_modules/@walletconnect/types": {
+    "node_modules/@reown/appkit-adapter-wagmi/node_modules/@walletconnect/types": {
       "version": "2.23.7",
       "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.7.tgz",
       "integrity": "sha512-6PAKK+iR2IntmlkCFLMAHjYeIaerCJJYRDmdRimhon0u+aNmQT+HyGM6zxDAth0rdpBD7qEvKP5IXZTE7KFUhw==",
@@ -4043,7 +4045,7 @@
         "events": "3.3.0"
       }
     },
-    "node_modules/@reown/appkit-adapter-ethers5/node_modules/@walletconnect/universal-provider": {
+    "node_modules/@reown/appkit-adapter-wagmi/node_modules/@walletconnect/universal-provider": {
       "version": "2.23.7",
       "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.23.7.tgz",
       "integrity": "sha512-6UicU/Mhr/1bh7MNoajypz7BhigORbHpP1LFTf8FYLQGDqzmqHMqmMH2GDAImtaY2sFTi2jBvc22tLl8VMze/A==",
@@ -4063,7 +4065,7 @@
         "events": "3.3.0"
       }
     },
-    "node_modules/@reown/appkit-adapter-ethers5/node_modules/es-toolkit": {
+    "node_modules/@reown/appkit-adapter-wagmi/node_modules/es-toolkit": {
       "version": "1.44.0",
       "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
       "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
@@ -4073,13 +4075,13 @@
         "benchmarks"
       ]
     },
-    "node_modules/@reown/appkit-adapter-ethers5/node_modules/proxy-compare": {
+    "node_modules/@reown/appkit-adapter-wagmi/node_modules/proxy-compare": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-3.0.1.tgz",
       "integrity": "sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==",
       "license": "MIT"
     },
-    "node_modules/@reown/appkit-adapter-ethers5/node_modules/valtio": {
+    "node_modules/@reown/appkit-adapter-wagmi/node_modules/valtio": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/valtio/-/valtio-2.1.7.tgz",
       "integrity": "sha512-DwJhCDpujuQuKdJ2H84VbTjEJJteaSmqsuUltsfbfdbotVfNeTE4K/qc/Wi57I9x8/2ed4JNdjEna7O6PfavRg==",
@@ -10396,7 +10398,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
       "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
@@ -10892,7 +10895,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
       "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/big.js": {
       "version": "6.2.2",
@@ -12976,55 +12980,6 @@
         "scrypt-js": "^3.0.0",
         "secp256k1": "^4.0.1",
         "setimmediate": "^1.0.5"
-      }
-    },
-    "node_modules/ethers": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.8.0.tgz",
-      "integrity": "sha512-DUq+7fHrCg1aPDFCHx6UIPb3nmt2XMpM7Y/g2gLhsl3lIBqeAfOJIl1qEvRf2uq3BiKxmh6Fh5pfp2ieyek7Kg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@ethersproject/abi": "5.8.0",
-        "@ethersproject/abstract-provider": "5.8.0",
-        "@ethersproject/abstract-signer": "5.8.0",
-        "@ethersproject/address": "5.8.0",
-        "@ethersproject/base64": "5.8.0",
-        "@ethersproject/basex": "5.8.0",
-        "@ethersproject/bignumber": "5.8.0",
-        "@ethersproject/bytes": "5.8.0",
-        "@ethersproject/constants": "5.8.0",
-        "@ethersproject/contracts": "5.8.0",
-        "@ethersproject/hash": "5.8.0",
-        "@ethersproject/hdnode": "5.8.0",
-        "@ethersproject/json-wallets": "5.8.0",
-        "@ethersproject/keccak256": "5.8.0",
-        "@ethersproject/logger": "5.8.0",
-        "@ethersproject/networks": "5.8.0",
-        "@ethersproject/pbkdf2": "5.8.0",
-        "@ethersproject/properties": "5.8.0",
-        "@ethersproject/providers": "5.8.0",
-        "@ethersproject/random": "5.8.0",
-        "@ethersproject/rlp": "5.8.0",
-        "@ethersproject/sha2": "5.8.0",
-        "@ethersproject/signing-key": "5.8.0",
-        "@ethersproject/solidity": "5.8.0",
-        "@ethersproject/strings": "5.8.0",
-        "@ethersproject/transactions": "5.8.0",
-        "@ethersproject/units": "5.8.0",
-        "@ethersproject/wallet": "5.8.0",
-        "@ethersproject/web": "5.8.0",
-        "@ethersproject/wordlists": "5.8.0"
       }
     },
     "node_modules/ethjs-unit": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@web3-react/injected-connector": "^6.0.7",
         "@web3-react/network-connector": "^6.1.3",
         "@web3-react/walletlink-connector": "^6.2.13",
-        "ethers": "^5.7.2",
         "magic-sdk": "^27.0.0",
         "thirdweb": "^5.119.0",
         "tslib": "^2.8.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,12 @@
         "@dcl/schemas": "^22.1.0",
         "@magic-ext/oauth2": "15.3.2-canary.1040.22248562051.0",
         "@reown/appkit": "^1.8.15",
+        "@reown/appkit-adapter-ethers5": "^1.8.15",
         "@web3-react/fortmatic-connector": "^6.1.6",
         "@web3-react/injected-connector": "^6.0.7",
         "@web3-react/network-connector": "^6.1.3",
         "@web3-react/walletlink-connector": "^6.2.13",
+        "ethers": "^5.7.2",
         "magic-sdk": "^27.0.0",
         "thirdweb": "^5.119.0",
         "tslib": "^2.8.1"
@@ -67,6 +69,7 @@
       "version": "7.28.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -769,6 +772,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -1209,6 +1213,81 @@
         "node": ">=14"
       }
     },
+    "node_modules/@ethersproject/abi": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.8.0.tgz",
+      "integrity": "sha512-b9YS/43ObplgyV6SlyQsG53/vkSal0MNA1fskSC4mbnCMi8R+NkcH8K9FPYNESf6jUefBUniE4SOKms0E/KK1Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/hash": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/abstract-provider": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.8.0.tgz",
+      "integrity": "sha512-wC9SFcmh4UK0oKuLJQItoQdzS/qZ51EJegK6EmAWlh+OptpQ/npECOR3QqECd8iGHC0RJb4WKbVdSfif4ammrg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/networks": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/transactions": "^5.8.0",
+        "@ethersproject/web": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/abstract-signer": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.8.0.tgz",
+      "integrity": "sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0"
+      }
+    },
     "node_modules/@ethersproject/address": {
       "version": "5.8.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.8.0.tgz",
@@ -1230,6 +1309,45 @@
         "@ethersproject/keccak256": "^5.8.0",
         "@ethersproject/logger": "^5.8.0",
         "@ethersproject/rlp": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/base64": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.8.0.tgz",
+      "integrity": "sha512-lN0oIwfkYj9LbPx4xEkie6rAMJtySbpOAFXSDVQaBnAzYfB4X2Qr+FXJGxMoc3Bxp2Sm8OwvzMrywxyw0gLjIQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/basex": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.8.0.tgz",
+      "integrity": "sha512-PIgTszMlDRmNwW9nhS6iqtVfdTAKosA7llYXNmGPw4YAI1PUyMv28988wAb41/gHF/WqGdoLv0erHaRcHRKW2Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0"
       }
     },
     "node_modules/@ethersproject/bignumber": {
@@ -1291,6 +1409,122 @@
         "@ethersproject/bignumber": "^5.8.0"
       }
     },
+    "node_modules/@ethersproject/contracts": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.8.0.tgz",
+      "integrity": "sha512-0eFjGz9GtuAi6MZwhb4uvUM216F38xiuR0yYCjKJpNfSEy4HUM8hvqqBj9Jmm0IUz8l0xKEhWwLIhPgxNY0yvQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abi": "^5.8.0",
+        "@ethersproject/abstract-provider": "^5.8.0",
+        "@ethersproject/abstract-signer": "^5.8.0",
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/transactions": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/hash": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.8.0.tgz",
+      "integrity": "sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.8.0",
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/base64": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/hdnode": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.8.0.tgz",
+      "integrity": "sha512-4bK1VF6E83/3/Im0ERnnUeWOY3P1BZml4ZD3wcH8Ys0/d1h1xaFt6Zc+Dh9zXf9TapGro0T4wvO71UTCp3/uoA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.8.0",
+        "@ethersproject/basex": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/pbkdf2": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/sha2": "^5.8.0",
+        "@ethersproject/signing-key": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0",
+        "@ethersproject/transactions": "^5.8.0",
+        "@ethersproject/wordlists": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/json-wallets": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.8.0.tgz",
+      "integrity": "sha512-HxblNck8FVUtNxS3VTEYJAcwiKYsBIF77W15HufqlBF9gGfhmYOJtYZp8fSDZtn9y5EaXTE87zDwzxRoTFk11w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.8.0",
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/hdnode": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/pbkdf2": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/random": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0",
+        "@ethersproject/transactions": "^5.8.0",
+        "aes-js": "3.0.0",
+        "scrypt-js": "3.0.1"
+      }
+    },
     "node_modules/@ethersproject/keccak256": {
       "version": "5.8.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.8.0.tgz",
@@ -1327,6 +1561,45 @@
       ],
       "license": "MIT"
     },
+    "node_modules/@ethersproject/networks": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.8.0.tgz",
+      "integrity": "sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/pbkdf2": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.8.0.tgz",
+      "integrity": "sha512-wuHiv97BrzCmfEaPbUFpMjlVg/IDkZThp9Ri88BpjRleg4iePJaj2SW8AIyE8cXn5V1tuAaMj6lzvsGJkGWskg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/sha2": "^5.8.0"
+      }
+    },
     "node_modules/@ethersproject/properties": {
       "version": "5.8.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.8.0.tgz",
@@ -1343,6 +1616,85 @@
       ],
       "license": "MIT",
       "dependencies": {
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/providers": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.8.0.tgz",
+      "integrity": "sha512-3Il3oTzEx3o6kzcg9ZzbE+oCZYyY+3Zh83sKkn4s1DZfTUjIegHnN2Cm0kbn9YFy45FDVcuCLLONhU7ny0SsCw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.8.0",
+        "@ethersproject/abstract-signer": "^5.8.0",
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/base64": "^5.8.0",
+        "@ethersproject/basex": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/hash": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/networks": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/random": "^5.8.0",
+        "@ethersproject/rlp": "^5.8.0",
+        "@ethersproject/sha2": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0",
+        "@ethersproject/transactions": "^5.8.0",
+        "@ethersproject/web": "^5.8.0",
+        "bech32": "1.1.4",
+        "ws": "8.18.0"
+      }
+    },
+    "node_modules/@ethersproject/providers/node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ethersproject/random": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.8.0.tgz",
+      "integrity": "sha512-E4I5TDl7SVqyg4/kkA/qTfuLWAQGXmSOgYyO01So8hLfwgKvYK5snIlzxJMk72IFdG/7oh8yuSqY2KX7MMwg+A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
         "@ethersproject/logger": "^5.8.0"
       }
     },
@@ -1364,6 +1716,28 @@
       "dependencies": {
         "@ethersproject/bytes": "^5.8.0",
         "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/sha2": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.8.0.tgz",
+      "integrity": "sha512-dDOUrXr9wF/YFltgTBYS0tKslPEKr6AekjqDW2dbn1L1xmjGR+9GiKu4ajxovnrDbwxAKdHjW8jNcwfz8PAz4A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "hash.js": "1.1.7"
       }
     },
     "node_modules/@ethersproject/signing-key": {
@@ -1388,6 +1762,51 @@
         "bn.js": "^5.2.1",
         "elliptic": "6.6.1",
         "hash.js": "1.1.7"
+      }
+    },
+    "node_modules/@ethersproject/solidity": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.8.0.tgz",
+      "integrity": "sha512-4CxFeCgmIWamOHwYN9d+QWGxye9qQLilpgTU0XhYs1OahkclF+ewO+3V1U0mvpiuQxm5EHHmv8f7ClVII8EHsA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/sha2": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/strings": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.8.0.tgz",
+      "integrity": "sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0"
       }
     },
     "node_modules/@ethersproject/transactions": {
@@ -1415,6 +1834,106 @@
         "@ethersproject/properties": "^5.8.0",
         "@ethersproject/rlp": "^5.8.0",
         "@ethersproject/signing-key": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/units": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.8.0.tgz",
+      "integrity": "sha512-lxq0CAnc5kMGIiWW4Mr041VT8IhNM+Pn5T3haO74XZWFulk7wH1Gv64HqE96hT4a7iiNMdOCFEBgaxWuk8ETKQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/wallet": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.8.0.tgz",
+      "integrity": "sha512-G+jnzmgg6UxurVKRKvw27h0kvG75YKXZKdlLYmAHeF32TGUzHkOFd7Zn6QHOTYRFWnfjtSSFjBowKo7vfrXzPA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.8.0",
+        "@ethersproject/abstract-signer": "^5.8.0",
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/hash": "^5.8.0",
+        "@ethersproject/hdnode": "^5.8.0",
+        "@ethersproject/json-wallets": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/random": "^5.8.0",
+        "@ethersproject/signing-key": "^5.8.0",
+        "@ethersproject/transactions": "^5.8.0",
+        "@ethersproject/wordlists": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/web": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.8.0.tgz",
+      "integrity": "sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/base64": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/wordlists": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.8.0.tgz",
+      "integrity": "sha512-2df9bbXicZws2Sb5S6ET493uJ0Z84Fjr3pC4tu/qlnZERibZCeUVuqdtt+7Tv9xxhUxHoIekIA7avrKUWHrezg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/hash": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -1534,7 +2053,6 @@
       "resolved": "https://registry.npmjs.org/@hey-api/codegen-core/-/codegen-core-0.7.0.tgz",
       "integrity": "sha512-HglL4B4QwpzocE+c8qDU6XK8zMf8W8Pcv0RpFDYxHuYALWLTnpDUuEsglC7NQ4vC1maoXsBpMbmwpco0N4QviA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hey-api/types": "0.1.3",
         "ansi-colors": "4.1.3",
@@ -1556,7 +2074,6 @@
       "resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.3.1.tgz",
       "integrity": "sha512-7atnpUkT8TyUPHYPLk91j/GyaqMuwTEHanLOe50Dlx0EEvNuQqFD52Yjg8x4KU0UFL1mWlyhE+sUE/wAtQ1N2A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jsdevtools/ono": "7.1.3",
         "@types/json-schema": "7.0.15",
@@ -1574,7 +2091,6 @@
       "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.93.0.tgz",
       "integrity": "sha512-LzYpKHRSasPGJFP+UvgrvlhLBa5W0roqKJKAJCTbAMpAKutC0jcWegkYXD3m85RFpBU2aXFDJrG99hf3xw1QMA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hey-api/codegen-core": "0.7.0",
         "@hey-api/json-schema-ref-parser": "1.3.1",
@@ -1602,7 +2118,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
       "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -1612,7 +2127,6 @@
       "resolved": "https://registry.npmjs.org/@hey-api/shared/-/shared-0.2.1.tgz",
       "integrity": "sha512-uWI9047e9OVe3Ss+6vPMnRiixjRcjcBbdgpeq4IQymet3+wsn0+N/4RLDHBz1h57SemaxayPRUA0JOOsuC1qyA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hey-api/codegen-core": "0.7.0",
         "@hey-api/json-schema-ref-parser": "1.3.1",
@@ -1637,7 +2151,6 @@
       "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
       "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "default-browser": "^5.4.0",
         "define-lazy-prop": "^3.0.0",
@@ -1658,7 +2171,6 @@
       "resolved": "https://registry.npmjs.org/@hey-api/types/-/types-0.1.3.tgz",
       "integrity": "sha512-mZaiPOWH761yD4GjDQvtjS2ZYLu5o5pI1TVSvV/u7cmbybv51/FVtinFBeaE1kFQCKZ8OQpn2ezjLBJrKsGATw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "typescript": ">=5.5.3"
       }
@@ -2238,8 +2750,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.5.1",
@@ -2290,6 +2801,7 @@
       "resolved": "https://registry.npmjs.org/@magic-sdk/provider/-/provider-27.0.0.tgz",
       "integrity": "sha512-k2haK2zhYkqf+cbMF+/HKvqa8qPWqdZbW10qgN6AdqaOE750ceC3GDQCUwAfkzdofmWrRtFgW5jVAVCVz5WklQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@magic-sdk/types": "^23.0.0",
         "eventemitter3": "^4.0.4",
@@ -2309,7 +2821,8 @@
       "version": "23.0.0",
       "resolved": "https://registry.npmjs.org/@magic-sdk/types/-/types-23.0.0.tgz",
       "integrity": "sha512-NTjgGPJVYxoncSrHtDZLDiJzdSbxHV0jCy6J+YvT+LY7QUiGY3zzu+NhLqgLxE6KZODXERhSLYSimotcokZbmw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@metamask/eth-json-rpc-provider": {
       "version": "1.0.1",
@@ -2654,6 +3167,7 @@
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
       "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-fetch": "^2.7.0"
       }
@@ -2733,6 +3247,7 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -2841,17 +3356,6 @@
       "license": "MIT",
       "dependencies": {
         "lit": "^3"
-      }
-    },
-    "node_modules/@phosphor-icons/webcomponents/node_modules/lit": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
-      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit/reactive-element": "^2.1.0",
-        "lit-element": "^4.2.0",
-        "lit-html": "^3.3.0"
       }
     },
     "node_modules/@pkgr/core": {
@@ -3362,79 +3866,119 @@
       "license": "MIT"
     },
     "node_modules/@reown/appkit": {
-      "version": "1.8.16",
-      "resolved": "https://registry.npmjs.org/@reown/appkit/-/appkit-1.8.16.tgz",
-      "integrity": "sha512-EleChIVOXa8qylNCcllByP+AYIoktDmPGfavi3Fn4eWWXoc4wlfL58NEiETbCyi1ZgUtaZUfIUiMvwgjJ4+mwQ==",
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit/-/appkit-1.8.19.tgz",
+      "integrity": "sha512-wB+xatkRbOy0AY1cZxxtcKzzPk3l3CTFulDbaISLVmZI6ZnQrOFuLnYc285zGsC6DB4d6bmwYUh89zcMLa4PvQ==",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.8.16",
-        "@reown/appkit-controllers": "1.8.16",
-        "@reown/appkit-pay": "1.8.16",
-        "@reown/appkit-polyfills": "1.8.16",
-        "@reown/appkit-scaffold-ui": "1.8.16",
-        "@reown/appkit-ui": "1.8.16",
-        "@reown/appkit-utils": "1.8.16",
-        "@reown/appkit-wallet": "1.8.16",
-        "@walletconnect/universal-provider": "2.23.1",
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-controllers": "1.8.19",
+        "@reown/appkit-pay": "1.8.19",
+        "@reown/appkit-polyfills": "1.8.19",
+        "@reown/appkit-scaffold-ui": "1.8.19",
+        "@reown/appkit-ui": "1.8.19",
+        "@reown/appkit-utils": "1.8.19",
+        "@reown/appkit-wallet": "1.8.19",
+        "@walletconnect/universal-provider": "2.23.7",
         "bs58": "6.0.0",
         "semver": "7.7.2",
         "valtio": "2.1.7",
-        "viem": ">=2.37.9"
+        "viem": ">=2.45.0"
       },
       "optionalDependencies": {
         "@lit/react": "1.0.8"
       }
     },
-    "node_modules/@reown/appkit-common": {
-      "version": "1.8.16",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.8.16.tgz",
-      "integrity": "sha512-og7EkTEI+mxTEEK3cRoX2PJqgij/5t9CJeN/2dnOef8mEiNh0vAPmdzZPXw9v4oVeBsu14jb8n/Y7vIbTOwl6Q==",
+    "node_modules/@reown/appkit-adapter-ethers5": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-adapter-ethers5/-/appkit-adapter-ethers5-1.8.19.tgz",
+      "integrity": "sha512-Q45k6XCg2IdvKbkTlJVLJdkVkyje8NAvF+FkazSrtC0d4CXTOPfkR0tTsoW2GoB/L2nGgxEmniOMfWv5Rr9JvQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "big.js": "6.2.2",
-        "dayjs": "1.11.13",
-        "viem": ">=2.37.9"
+        "@reown/appkit": "1.8.19",
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-controllers": "1.8.19",
+        "@reown/appkit-polyfills": "1.8.19",
+        "@reown/appkit-scaffold-ui": "1.8.19",
+        "@reown/appkit-utils": "1.8.19",
+        "@reown/appkit-wallet": "1.8.19",
+        "@walletconnect/universal-provider": "2.23.7",
+        "valtio": "2.1.7"
+      },
+      "peerDependencies": {
+        "@ethersproject/sha2": "5.8.0",
+        "ethers": ">=4.1 <6.0.0"
       }
     },
-    "node_modules/@reown/appkit-controllers": {
-      "version": "1.8.16",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-controllers/-/appkit-controllers-1.8.16.tgz",
-      "integrity": "sha512-GzhC+/AAYoyLYs/jJd7/D/tv7WCoB4wfv6VkpYcS+3NjL1orGqYnPIXiieiDEGwbfM8h08lmlCsEwOrEoIrchA==",
+    "node_modules/@reown/appkit-adapter-ethers5/node_modules/@reown/appkit-pay": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.8.19.tgz",
+      "integrity": "sha512-HO/tQT0TbTQO3eONxNNPJAOZAOzUiHvjM0Mty1rFFeRBH68auiqQxQi2YFNMs014gNkRN+cb84VYau7+MCC0fQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.8.16",
-        "@reown/appkit-wallet": "1.8.16",
-        "@walletconnect/universal-provider": "2.23.1",
-        "valtio": "2.1.7",
-        "viem": ">=2.37.9"
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-controllers": "1.8.19",
+        "@reown/appkit-ui": "1.8.19",
+        "@reown/appkit-utils": "1.8.19",
+        "lit": "3.3.0",
+        "valtio": "2.1.7"
       }
     },
-    "node_modules/@reown/appkit-controllers/node_modules/@reown/appkit-polyfills": {
-      "version": "1.8.16",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.8.16.tgz",
-      "integrity": "sha512-6ArFDoIbI/DHHCdOCSnh7THP4OvhG5XKKgXbCKSNOuj3/RPl3OmmoFJwwf+LvZJ4ggaz7I6qoXFHf8fEEx1FcQ==",
+    "node_modules/@reown/appkit-adapter-ethers5/node_modules/@reown/appkit-polyfills": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.8.19.tgz",
+      "integrity": "sha512-PSoetRSuZg7f2YFPzdfs4BayQl51zcGqYr7frwOe6td0XEsspLrrVFn/zk5QFbFHZVsMdfRZ+TTunt84ozRdnQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "buffer": "6.0.3"
       }
     },
-    "node_modules/@reown/appkit-controllers/node_modules/@reown/appkit-wallet": {
-      "version": "1.8.16",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.8.16.tgz",
-      "integrity": "sha512-UARNgRtzTVojDv2wgILy7RKiYAXpFX9UE7qkficV4oB+IQX7yCPpa0eXN2mDXZBVSz2hSu4rLTa7WNXzZPal/A==",
+    "node_modules/@reown/appkit-adapter-ethers5/node_modules/@reown/appkit-scaffold-ui": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-scaffold-ui/-/appkit-scaffold-ui-1.8.19.tgz",
+      "integrity": "sha512-Ak767x0VzeDIXb0wbzkl19kx6udw7vkb1EU0SAweG3iKc9BunW87Rfcd48/YimzMZycJaYmlbtfmqQQDYs6Few==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.8.16",
-        "@reown/appkit-polyfills": "1.8.16",
-        "@walletconnect/logger": "3.0.1",
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-controllers": "1.8.19",
+        "@reown/appkit-pay": "1.8.19",
+        "@reown/appkit-ui": "1.8.19",
+        "@reown/appkit-utils": "1.8.19",
+        "@reown/appkit-wallet": "1.8.19",
+        "lit": "3.3.0"
+      }
+    },
+    "node_modules/@reown/appkit-adapter-ethers5/node_modules/@reown/appkit-ui": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.8.19.tgz",
+      "integrity": "sha512-fCAwW8yyyC3JcgKLBPvCtYuDGC4H8anO7u4LTaAXGEzdcU5H+IrCgNFSPNK7NuTSmgXm1TnoYxPxRFKNiNwFdA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@phosphor-icons/webcomponents": "2.1.5",
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-controllers": "1.8.19",
+        "@reown/appkit-wallet": "1.8.19",
+        "lit": "3.3.0",
+        "qrcode": "1.5.3"
+      }
+    },
+    "node_modules/@reown/appkit-adapter-ethers5/node_modules/@reown/appkit-wallet": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.8.19.tgz",
+      "integrity": "sha512-NVdIKceUhkXYtsG32925ctmVn0QJFNyDlr+mWheMLCEZ/IUPn+6aA53vTVaSUquhyeFxUXtrCOh3ln6v1tup5w==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-polyfills": "1.8.19",
+        "@walletconnect/logger": "3.0.2",
         "zod": "3.22.4"
       }
     },
-    "node_modules/@reown/appkit-controllers/node_modules/@walletconnect/core": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.1.tgz",
-      "integrity": "sha512-fW48PIw41Q/LJW+q0msFogD/OcelkrrDONQMcpGw4C4Y6w+IvFKGEg+7dxGLKWx1g8QuHk/p6C9VEIV/tDsm5A==",
+    "node_modules/@reown/appkit-adapter-ethers5/node_modules/@walletconnect/core": {
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.7.tgz",
+      "integrity": "sha512-yTyymn9mFaDZkUfLfZ3E9VyaSDPeHAXlrPxQRmNx2zFsEt/25GmTU2A848aomimLxZnAG2jNLhxbJ8I0gyNV+w==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.2",
@@ -3443,15 +3987,15 @@
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/jsonrpc-ws-connection": "1.0.16",
         "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/logger": "3.0.1",
+        "@walletconnect/logger": "3.0.2",
         "@walletconnect/relay-api": "1.0.11",
         "@walletconnect/relay-auth": "1.1.0",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.23.1",
-        "@walletconnect/utils": "2.23.1",
+        "@walletconnect/types": "2.23.7",
+        "@walletconnect/utils": "2.23.7",
         "@walletconnect/window-getters": "1.0.1",
-        "es-toolkit": "1.39.3",
+        "es-toolkit": "1.44.0",
         "events": "3.3.0",
         "uint8arrays": "3.1.1"
       },
@@ -3459,51 +4003,51 @@
         "node": ">=18.20.8"
       }
     },
-    "node_modules/@reown/appkit-controllers/node_modules/@walletconnect/logger": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.1.tgz",
-      "integrity": "sha512-O8lXGMZO1+e5NtHhBSjsAih/I9KC+1BxNhGNGD+SIWTqWd0zsbT5wJtNnJ+LnSXTRE7XZRxFUlvZgkER3vlhFA==",
+    "node_modules/@reown/appkit-adapter-ethers5/node_modules/@walletconnect/logger": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.2.tgz",
+      "integrity": "sha512-7wR3wAwJTOmX4gbcUZcFMov8fjftY05+5cO/d4cpDD8wDzJ+cIlKdYOXaXfxHLSYeDazMXIsxMYjHYVDfkx+nA==",
       "license": "MIT",
       "dependencies": {
         "@walletconnect/safe-json": "^1.0.2",
         "pino": "10.0.0"
       }
     },
-    "node_modules/@reown/appkit-controllers/node_modules/@walletconnect/sign-client": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.23.1.tgz",
-      "integrity": "sha512-x0sG8ZuuaOi3G/gYWLppf7nmNItWlV8Yga9Bltb46/Ve6G20nCBis6gcTVVeJOpnmqQ85FISwExqOYPmJ0FQlw==",
+    "node_modules/@reown/appkit-adapter-ethers5/node_modules/@walletconnect/sign-client": {
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.23.7.tgz",
+      "integrity": "sha512-SX61lzb1bTl/LijlcHQttnoHPBzzoY5mW9ArR6qhFtDNDTS7yr2rcH7rCngxHlYeb4rAYcWLHgbiGSrdKxl/mg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@walletconnect/core": "2.23.1",
+        "@walletconnect/core": "2.23.7",
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/logger": "3.0.1",
+        "@walletconnect/logger": "3.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.23.1",
-        "@walletconnect/utils": "2.23.1",
+        "@walletconnect/types": "2.23.7",
+        "@walletconnect/utils": "2.23.7",
         "events": "3.3.0"
       }
     },
-    "node_modules/@reown/appkit-controllers/node_modules/@walletconnect/types": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.1.tgz",
-      "integrity": "sha512-sbWOM9oCuzSbz/187rKWnSB3sy7FCFcbTQYeIJMc9+HTMTG2TUPftPCn8NnkfvmXbIeyLw00Y0KNvXoCV/eIeQ==",
+    "node_modules/@reown/appkit-adapter-ethers5/node_modules/@walletconnect/types": {
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.7.tgz",
+      "integrity": "sha512-6PAKK+iR2IntmlkCFLMAHjYeIaerCJJYRDmdRimhon0u+aNmQT+HyGM6zxDAth0rdpBD7qEvKP5IXZTE7KFUhw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-types": "1.0.4",
         "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/logger": "3.0.1",
+        "@walletconnect/logger": "3.0.2",
         "events": "3.3.0"
       }
     },
-    "node_modules/@reown/appkit-controllers/node_modules/@walletconnect/universal-provider": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.23.1.tgz",
-      "integrity": "sha512-XlvG1clsL7Ds+g28Oz5dXsPA+5ERtQGYvd+L8cskMaTvtphGhipVGgX8WNAhp7p1gfNcDg4tCiTHlj131jctwA==",
+    "node_modules/@reown/appkit-adapter-ethers5/node_modules/@walletconnect/universal-provider": {
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.23.7.tgz",
+      "integrity": "sha512-6UicU/Mhr/1bh7MNoajypz7BhigORbHpP1LFTf8FYLQGDqzmqHMqmMH2GDAImtaY2sFTi2jBvc22tLl8VMze/A==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
@@ -3512,13 +4056,197 @@
         "@walletconnect/jsonrpc-types": "1.0.4",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/logger": "3.0.1",
-        "@walletconnect/sign-client": "2.23.1",
-        "@walletconnect/types": "2.23.1",
-        "@walletconnect/utils": "2.23.1",
-        "es-toolkit": "1.39.3",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/sign-client": "2.23.7",
+        "@walletconnect/types": "2.23.7",
+        "@walletconnect/utils": "2.23.7",
+        "es-toolkit": "1.44.0",
         "events": "3.3.0"
       }
+    },
+    "node_modules/@reown/appkit-adapter-ethers5/node_modules/es-toolkit": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+      "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
+    "node_modules/@reown/appkit-adapter-ethers5/node_modules/proxy-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-3.0.1.tgz",
+      "integrity": "sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==",
+      "license": "MIT"
+    },
+    "node_modules/@reown/appkit-adapter-ethers5/node_modules/valtio": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/valtio/-/valtio-2.1.7.tgz",
+      "integrity": "sha512-DwJhCDpujuQuKdJ2H84VbTjEJJteaSmqsuUltsfbfdbotVfNeTE4K/qc/Wi57I9x8/2ed4JNdjEna7O6PfavRg==",
+      "license": "MIT",
+      "dependencies": {
+        "proxy-compare": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "react": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reown/appkit-common": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.8.19.tgz",
+      "integrity": "sha512-z5wDrYjUGY7YbM4b14NHVo54WKZ5++PQtGkcsXhiOP39yAVijubBQD8BfHs/Pu2fSFqnqLIFoCVvIEfNWWccRw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "big.js": "6.2.2",
+        "dayjs": "1.11.13",
+        "viem": ">=2.45.0"
+      }
+    },
+    "node_modules/@reown/appkit-controllers": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-controllers/-/appkit-controllers-1.8.19.tgz",
+      "integrity": "sha512-JFNT8CfAVit9FJXh596Ye4U8A/oIapW+Y0KQqjB59DXyTCDZbxZDB32rULBQrSkZ6PufTEa239Dil4kABCQKtg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-wallet": "1.8.19",
+        "@walletconnect/universal-provider": "2.23.7",
+        "valtio": "2.1.7",
+        "viem": ">=2.45.0"
+      }
+    },
+    "node_modules/@reown/appkit-controllers/node_modules/@reown/appkit-polyfills": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.8.19.tgz",
+      "integrity": "sha512-PSoetRSuZg7f2YFPzdfs4BayQl51zcGqYr7frwOe6td0XEsspLrrVFn/zk5QFbFHZVsMdfRZ+TTunt84ozRdnQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "buffer": "6.0.3"
+      }
+    },
+    "node_modules/@reown/appkit-controllers/node_modules/@reown/appkit-wallet": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.8.19.tgz",
+      "integrity": "sha512-NVdIKceUhkXYtsG32925ctmVn0QJFNyDlr+mWheMLCEZ/IUPn+6aA53vTVaSUquhyeFxUXtrCOh3ln6v1tup5w==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-polyfills": "1.8.19",
+        "@walletconnect/logger": "3.0.2",
+        "zod": "3.22.4"
+      }
+    },
+    "node_modules/@reown/appkit-controllers/node_modules/@walletconnect/core": {
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.7.tgz",
+      "integrity": "sha512-yTyymn9mFaDZkUfLfZ3E9VyaSDPeHAXlrPxQRmNx2zFsEt/25GmTU2A848aomimLxZnAG2jNLhxbJ8I0gyNV+w==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-provider": "1.0.14",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.16",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/relay-api": "1.0.11",
+        "@walletconnect/relay-auth": "1.1.0",
+        "@walletconnect/safe-json": "1.0.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.23.7",
+        "@walletconnect/utils": "2.23.7",
+        "@walletconnect/window-getters": "1.0.1",
+        "es-toolkit": "1.44.0",
+        "events": "3.3.0",
+        "uint8arrays": "3.1.1"
+      },
+      "engines": {
+        "node": ">=18.20.8"
+      }
+    },
+    "node_modules/@reown/appkit-controllers/node_modules/@walletconnect/logger": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.2.tgz",
+      "integrity": "sha512-7wR3wAwJTOmX4gbcUZcFMov8fjftY05+5cO/d4cpDD8wDzJ+cIlKdYOXaXfxHLSYeDazMXIsxMYjHYVDfkx+nA==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.2",
+        "pino": "10.0.0"
+      }
+    },
+    "node_modules/@reown/appkit-controllers/node_modules/@walletconnect/sign-client": {
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.23.7.tgz",
+      "integrity": "sha512-SX61lzb1bTl/LijlcHQttnoHPBzzoY5mW9ArR6qhFtDNDTS7yr2rcH7rCngxHlYeb4rAYcWLHgbiGSrdKxl/mg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/core": "2.23.7",
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.23.7",
+        "@walletconnect/utils": "2.23.7",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@reown/appkit-controllers/node_modules/@walletconnect/types": {
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.7.tgz",
+      "integrity": "sha512-6PAKK+iR2IntmlkCFLMAHjYeIaerCJJYRDmdRimhon0u+aNmQT+HyGM6zxDAth0rdpBD7qEvKP5IXZTE7KFUhw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.2",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@reown/appkit-controllers/node_modules/@walletconnect/universal-provider": {
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.23.7.tgz",
+      "integrity": "sha512-6UicU/Mhr/1bh7MNoajypz7BhigORbHpP1LFTf8FYLQGDqzmqHMqmMH2GDAImtaY2sFTi2jBvc22tLl8VMze/A==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/jsonrpc-http-connection": "1.0.8",
+        "@walletconnect/jsonrpc-provider": "1.0.14",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/sign-client": "2.23.7",
+        "@walletconnect/types": "2.23.7",
+        "@walletconnect/utils": "2.23.7",
+        "es-toolkit": "1.44.0",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@reown/appkit-controllers/node_modules/es-toolkit": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+      "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/@reown/appkit-controllers/node_modules/proxy-compare": {
       "version": "3.0.1",
@@ -3934,6 +4662,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -4343,6 +5072,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -4723,6 +5453,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -4740,20 +5471,20 @@
       }
     },
     "node_modules/@reown/appkit-utils": {
-      "version": "1.8.16",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.8.16.tgz",
-      "integrity": "sha512-tCi2ZEOoOIGiddRAy9lJ1jnYj0zMnqEojIk095sWvnMdlNfn/lZdsLt62AGqk5khnlsyg2Zo0vszPBcXLH8/ww==",
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.8.19.tgz",
+      "integrity": "sha512-VQPgUMTFqoh4UD3EDZSw9wyMkyZsmIVmu8CdQ2FUxIuqYW4fLd0VIpkDeO64MMhSv8b0X8Vd6m4+eGcqSwlUAg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.8.16",
-        "@reown/appkit-controllers": "1.8.16",
-        "@reown/appkit-polyfills": "1.8.16",
-        "@reown/appkit-wallet": "1.8.16",
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-controllers": "1.8.19",
+        "@reown/appkit-polyfills": "1.8.19",
+        "@reown/appkit-wallet": "1.8.19",
         "@wallet-standard/wallet": "1.1.0",
-        "@walletconnect/logger": "3.0.1",
-        "@walletconnect/universal-provider": "2.23.1",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/universal-provider": "2.23.7",
         "valtio": "2.1.7",
-        "viem": ">=2.37.9"
+        "viem": ">=2.45.0"
       },
       "optionalDependencies": {
         "@base-org/account": "2.4.0",
@@ -4765,30 +5496,30 @@
       }
     },
     "node_modules/@reown/appkit-utils/node_modules/@reown/appkit-polyfills": {
-      "version": "1.8.16",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.8.16.tgz",
-      "integrity": "sha512-6ArFDoIbI/DHHCdOCSnh7THP4OvhG5XKKgXbCKSNOuj3/RPl3OmmoFJwwf+LvZJ4ggaz7I6qoXFHf8fEEx1FcQ==",
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.8.19.tgz",
+      "integrity": "sha512-PSoetRSuZg7f2YFPzdfs4BayQl51zcGqYr7frwOe6td0XEsspLrrVFn/zk5QFbFHZVsMdfRZ+TTunt84ozRdnQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "buffer": "6.0.3"
       }
     },
     "node_modules/@reown/appkit-utils/node_modules/@reown/appkit-wallet": {
-      "version": "1.8.16",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.8.16.tgz",
-      "integrity": "sha512-UARNgRtzTVojDv2wgILy7RKiYAXpFX9UE7qkficV4oB+IQX7yCPpa0eXN2mDXZBVSz2hSu4rLTa7WNXzZPal/A==",
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.8.19.tgz",
+      "integrity": "sha512-NVdIKceUhkXYtsG32925ctmVn0QJFNyDlr+mWheMLCEZ/IUPn+6aA53vTVaSUquhyeFxUXtrCOh3ln6v1tup5w==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.8.16",
-        "@reown/appkit-polyfills": "1.8.16",
-        "@walletconnect/logger": "3.0.1",
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-polyfills": "1.8.19",
+        "@walletconnect/logger": "3.0.2",
         "zod": "3.22.4"
       }
     },
     "node_modules/@reown/appkit-utils/node_modules/@walletconnect/core": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.1.tgz",
-      "integrity": "sha512-fW48PIw41Q/LJW+q0msFogD/OcelkrrDONQMcpGw4C4Y6w+IvFKGEg+7dxGLKWx1g8QuHk/p6C9VEIV/tDsm5A==",
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.7.tgz",
+      "integrity": "sha512-yTyymn9mFaDZkUfLfZ3E9VyaSDPeHAXlrPxQRmNx2zFsEt/25GmTU2A848aomimLxZnAG2jNLhxbJ8I0gyNV+w==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.2",
@@ -4797,15 +5528,15 @@
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/jsonrpc-ws-connection": "1.0.16",
         "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/logger": "3.0.1",
+        "@walletconnect/logger": "3.0.2",
         "@walletconnect/relay-api": "1.0.11",
         "@walletconnect/relay-auth": "1.1.0",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.23.1",
-        "@walletconnect/utils": "2.23.1",
+        "@walletconnect/types": "2.23.7",
+        "@walletconnect/utils": "2.23.7",
         "@walletconnect/window-getters": "1.0.1",
-        "es-toolkit": "1.39.3",
+        "es-toolkit": "1.44.0",
         "events": "3.3.0",
         "uint8arrays": "3.1.1"
       },
@@ -4814,9 +5545,9 @@
       }
     },
     "node_modules/@reown/appkit-utils/node_modules/@walletconnect/logger": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.1.tgz",
-      "integrity": "sha512-O8lXGMZO1+e5NtHhBSjsAih/I9KC+1BxNhGNGD+SIWTqWd0zsbT5wJtNnJ+LnSXTRE7XZRxFUlvZgkER3vlhFA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.2.tgz",
+      "integrity": "sha512-7wR3wAwJTOmX4gbcUZcFMov8fjftY05+5cO/d4cpDD8wDzJ+cIlKdYOXaXfxHLSYeDazMXIsxMYjHYVDfkx+nA==",
       "license": "MIT",
       "dependencies": {
         "@walletconnect/safe-json": "^1.0.2",
@@ -4824,40 +5555,40 @@
       }
     },
     "node_modules/@reown/appkit-utils/node_modules/@walletconnect/sign-client": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.23.1.tgz",
-      "integrity": "sha512-x0sG8ZuuaOi3G/gYWLppf7nmNItWlV8Yga9Bltb46/Ve6G20nCBis6gcTVVeJOpnmqQ85FISwExqOYPmJ0FQlw==",
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.23.7.tgz",
+      "integrity": "sha512-SX61lzb1bTl/LijlcHQttnoHPBzzoY5mW9ArR6qhFtDNDTS7yr2rcH7rCngxHlYeb4rAYcWLHgbiGSrdKxl/mg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@walletconnect/core": "2.23.1",
+        "@walletconnect/core": "2.23.7",
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/logger": "3.0.1",
+        "@walletconnect/logger": "3.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.23.1",
-        "@walletconnect/utils": "2.23.1",
+        "@walletconnect/types": "2.23.7",
+        "@walletconnect/utils": "2.23.7",
         "events": "3.3.0"
       }
     },
     "node_modules/@reown/appkit-utils/node_modules/@walletconnect/types": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.1.tgz",
-      "integrity": "sha512-sbWOM9oCuzSbz/187rKWnSB3sy7FCFcbTQYeIJMc9+HTMTG2TUPftPCn8NnkfvmXbIeyLw00Y0KNvXoCV/eIeQ==",
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.7.tgz",
+      "integrity": "sha512-6PAKK+iR2IntmlkCFLMAHjYeIaerCJJYRDmdRimhon0u+aNmQT+HyGM6zxDAth0rdpBD7qEvKP5IXZTE7KFUhw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-types": "1.0.4",
         "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/logger": "3.0.1",
+        "@walletconnect/logger": "3.0.2",
         "events": "3.3.0"
       }
     },
     "node_modules/@reown/appkit-utils/node_modules/@walletconnect/universal-provider": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.23.1.tgz",
-      "integrity": "sha512-XlvG1clsL7Ds+g28Oz5dXsPA+5ERtQGYvd+L8cskMaTvtphGhipVGgX8WNAhp7p1gfNcDg4tCiTHlj131jctwA==",
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.23.7.tgz",
+      "integrity": "sha512-6UicU/Mhr/1bh7MNoajypz7BhigORbHpP1LFTf8FYLQGDqzmqHMqmMH2GDAImtaY2sFTi2jBvc22tLl8VMze/A==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
@@ -4866,13 +5597,23 @@
         "@walletconnect/jsonrpc-types": "1.0.4",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/logger": "3.0.1",
-        "@walletconnect/sign-client": "2.23.1",
-        "@walletconnect/types": "2.23.1",
-        "@walletconnect/utils": "2.23.1",
-        "es-toolkit": "1.39.3",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/sign-client": "2.23.7",
+        "@walletconnect/types": "2.23.7",
+        "@walletconnect/utils": "2.23.7",
+        "es-toolkit": "1.44.0",
         "events": "3.3.0"
       }
+    },
+    "node_modules/@reown/appkit-utils/node_modules/es-toolkit": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+      "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/@reown/appkit-utils/node_modules/proxy-compare": {
       "version": "3.0.1",
@@ -4928,73 +5669,73 @@
       }
     },
     "node_modules/@reown/appkit/node_modules/@reown/appkit-pay": {
-      "version": "1.8.16",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.8.16.tgz",
-      "integrity": "sha512-V5M9SZnV00ogMeuQDwd0xY6Fa4+yU9NhmWISt0iiAGpNNtKdF+NWybWFbi2GkGjg4IvlJJBBgBlIZtmlZRq8SQ==",
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.8.19.tgz",
+      "integrity": "sha512-HO/tQT0TbTQO3eONxNNPJAOZAOzUiHvjM0Mty1rFFeRBH68auiqQxQi2YFNMs014gNkRN+cb84VYau7+MCC0fQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.8.16",
-        "@reown/appkit-controllers": "1.8.16",
-        "@reown/appkit-ui": "1.8.16",
-        "@reown/appkit-utils": "1.8.16",
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-controllers": "1.8.19",
+        "@reown/appkit-ui": "1.8.19",
+        "@reown/appkit-utils": "1.8.19",
         "lit": "3.3.0",
         "valtio": "2.1.7"
       }
     },
     "node_modules/@reown/appkit/node_modules/@reown/appkit-polyfills": {
-      "version": "1.8.16",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.8.16.tgz",
-      "integrity": "sha512-6ArFDoIbI/DHHCdOCSnh7THP4OvhG5XKKgXbCKSNOuj3/RPl3OmmoFJwwf+LvZJ4ggaz7I6qoXFHf8fEEx1FcQ==",
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.8.19.tgz",
+      "integrity": "sha512-PSoetRSuZg7f2YFPzdfs4BayQl51zcGqYr7frwOe6td0XEsspLrrVFn/zk5QFbFHZVsMdfRZ+TTunt84ozRdnQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "buffer": "6.0.3"
       }
     },
     "node_modules/@reown/appkit/node_modules/@reown/appkit-scaffold-ui": {
-      "version": "1.8.16",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-scaffold-ui/-/appkit-scaffold-ui-1.8.16.tgz",
-      "integrity": "sha512-OzTtxwLkE2RcJh4ai87DpXz1zM7twZOpFA6OKWVXPCe2BASLzXWtKmpW8XA6gpA54oEmG4PtoBW9ogv/Qd2e8Q==",
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-scaffold-ui/-/appkit-scaffold-ui-1.8.19.tgz",
+      "integrity": "sha512-Ak767x0VzeDIXb0wbzkl19kx6udw7vkb1EU0SAweG3iKc9BunW87Rfcd48/YimzMZycJaYmlbtfmqQQDYs6Few==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.8.16",
-        "@reown/appkit-controllers": "1.8.16",
-        "@reown/appkit-pay": "1.8.16",
-        "@reown/appkit-ui": "1.8.16",
-        "@reown/appkit-utils": "1.8.16",
-        "@reown/appkit-wallet": "1.8.16",
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-controllers": "1.8.19",
+        "@reown/appkit-pay": "1.8.19",
+        "@reown/appkit-ui": "1.8.19",
+        "@reown/appkit-utils": "1.8.19",
+        "@reown/appkit-wallet": "1.8.19",
         "lit": "3.3.0"
       }
     },
     "node_modules/@reown/appkit/node_modules/@reown/appkit-ui": {
-      "version": "1.8.16",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.8.16.tgz",
-      "integrity": "sha512-yd9BtyRUk6zAVQcc8W2t5qqXVHJUweiZ7y/tIeuaGDuG8zRWlWQTX6Q2ivBeLI2fZNix7Or90IpnlcdaOCo2Lw==",
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.8.19.tgz",
+      "integrity": "sha512-fCAwW8yyyC3JcgKLBPvCtYuDGC4H8anO7u4LTaAXGEzdcU5H+IrCgNFSPNK7NuTSmgXm1TnoYxPxRFKNiNwFdA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@phosphor-icons/webcomponents": "2.1.5",
-        "@reown/appkit-common": "1.8.16",
-        "@reown/appkit-controllers": "1.8.16",
-        "@reown/appkit-wallet": "1.8.16",
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-controllers": "1.8.19",
+        "@reown/appkit-wallet": "1.8.19",
         "lit": "3.3.0",
         "qrcode": "1.5.3"
       }
     },
     "node_modules/@reown/appkit/node_modules/@reown/appkit-wallet": {
-      "version": "1.8.16",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.8.16.tgz",
-      "integrity": "sha512-UARNgRtzTVojDv2wgILy7RKiYAXpFX9UE7qkficV4oB+IQX7yCPpa0eXN2mDXZBVSz2hSu4rLTa7WNXzZPal/A==",
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.8.19.tgz",
+      "integrity": "sha512-NVdIKceUhkXYtsG32925ctmVn0QJFNyDlr+mWheMLCEZ/IUPn+6aA53vTVaSUquhyeFxUXtrCOh3ln6v1tup5w==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.8.16",
-        "@reown/appkit-polyfills": "1.8.16",
-        "@walletconnect/logger": "3.0.1",
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-polyfills": "1.8.19",
+        "@walletconnect/logger": "3.0.2",
         "zod": "3.22.4"
       }
     },
     "node_modules/@reown/appkit/node_modules/@walletconnect/core": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.1.tgz",
-      "integrity": "sha512-fW48PIw41Q/LJW+q0msFogD/OcelkrrDONQMcpGw4C4Y6w+IvFKGEg+7dxGLKWx1g8QuHk/p6C9VEIV/tDsm5A==",
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.7.tgz",
+      "integrity": "sha512-yTyymn9mFaDZkUfLfZ3E9VyaSDPeHAXlrPxQRmNx2zFsEt/25GmTU2A848aomimLxZnAG2jNLhxbJ8I0gyNV+w==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.2",
@@ -5003,15 +5744,15 @@
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/jsonrpc-ws-connection": "1.0.16",
         "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/logger": "3.0.1",
+        "@walletconnect/logger": "3.0.2",
         "@walletconnect/relay-api": "1.0.11",
         "@walletconnect/relay-auth": "1.1.0",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.23.1",
-        "@walletconnect/utils": "2.23.1",
+        "@walletconnect/types": "2.23.7",
+        "@walletconnect/utils": "2.23.7",
         "@walletconnect/window-getters": "1.0.1",
-        "es-toolkit": "1.39.3",
+        "es-toolkit": "1.44.0",
         "events": "3.3.0",
         "uint8arrays": "3.1.1"
       },
@@ -5020,9 +5761,9 @@
       }
     },
     "node_modules/@reown/appkit/node_modules/@walletconnect/logger": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.1.tgz",
-      "integrity": "sha512-O8lXGMZO1+e5NtHhBSjsAih/I9KC+1BxNhGNGD+SIWTqWd0zsbT5wJtNnJ+LnSXTRE7XZRxFUlvZgkER3vlhFA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.2.tgz",
+      "integrity": "sha512-7wR3wAwJTOmX4gbcUZcFMov8fjftY05+5cO/d4cpDD8wDzJ+cIlKdYOXaXfxHLSYeDazMXIsxMYjHYVDfkx+nA==",
       "license": "MIT",
       "dependencies": {
         "@walletconnect/safe-json": "^1.0.2",
@@ -5030,40 +5771,40 @@
       }
     },
     "node_modules/@reown/appkit/node_modules/@walletconnect/sign-client": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.23.1.tgz",
-      "integrity": "sha512-x0sG8ZuuaOi3G/gYWLppf7nmNItWlV8Yga9Bltb46/Ve6G20nCBis6gcTVVeJOpnmqQ85FISwExqOYPmJ0FQlw==",
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.23.7.tgz",
+      "integrity": "sha512-SX61lzb1bTl/LijlcHQttnoHPBzzoY5mW9ArR6qhFtDNDTS7yr2rcH7rCngxHlYeb4rAYcWLHgbiGSrdKxl/mg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@walletconnect/core": "2.23.1",
+        "@walletconnect/core": "2.23.7",
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/logger": "3.0.1",
+        "@walletconnect/logger": "3.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.23.1",
-        "@walletconnect/utils": "2.23.1",
+        "@walletconnect/types": "2.23.7",
+        "@walletconnect/utils": "2.23.7",
         "events": "3.3.0"
       }
     },
     "node_modules/@reown/appkit/node_modules/@walletconnect/types": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.1.tgz",
-      "integrity": "sha512-sbWOM9oCuzSbz/187rKWnSB3sy7FCFcbTQYeIJMc9+HTMTG2TUPftPCn8NnkfvmXbIeyLw00Y0KNvXoCV/eIeQ==",
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.7.tgz",
+      "integrity": "sha512-6PAKK+iR2IntmlkCFLMAHjYeIaerCJJYRDmdRimhon0u+aNmQT+HyGM6zxDAth0rdpBD7qEvKP5IXZTE7KFUhw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-types": "1.0.4",
         "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/logger": "3.0.1",
+        "@walletconnect/logger": "3.0.2",
         "events": "3.3.0"
       }
     },
     "node_modules/@reown/appkit/node_modules/@walletconnect/universal-provider": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.23.1.tgz",
-      "integrity": "sha512-XlvG1clsL7Ds+g28Oz5dXsPA+5ERtQGYvd+L8cskMaTvtphGhipVGgX8WNAhp7p1gfNcDg4tCiTHlj131jctwA==",
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.23.7.tgz",
+      "integrity": "sha512-6UicU/Mhr/1bh7MNoajypz7BhigORbHpP1LFTf8FYLQGDqzmqHMqmMH2GDAImtaY2sFTi2jBvc22tLl8VMze/A==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
@@ -5072,13 +5813,23 @@
         "@walletconnect/jsonrpc-types": "1.0.4",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/logger": "3.0.1",
-        "@walletconnect/sign-client": "2.23.1",
-        "@walletconnect/types": "2.23.1",
-        "@walletconnect/utils": "2.23.1",
-        "es-toolkit": "1.39.3",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/sign-client": "2.23.7",
+        "@walletconnect/types": "2.23.7",
+        "@walletconnect/utils": "2.23.7",
+        "es-toolkit": "1.44.0",
         "events": "3.3.0"
       }
+    },
+    "node_modules/@reown/appkit/node_modules/es-toolkit": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+      "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/@reown/appkit/node_modules/proxy-compare": {
       "version": "3.0.1",
@@ -5602,6 +6353,7 @@
       "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-5.5.1.tgz",
       "integrity": "sha512-irKUGiV2yRoyf+4eGQ/ZeCRxa43yjFEL1DUI5B0DkcfZw3cr0VJtVJnrG8OtVF01vT0OUfYOcUn6zJW5TROHvQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/accounts": "5.5.1",
         "@solana/addresses": "5.5.1",
@@ -6389,6 +7141,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.81.5.tgz",
       "integrity": "sha512-lOf2KqRRiYWpQT86eeeftAGnjuTR35myTP8MXyvHa81VlomoAWNEd8x5vkcAfQefu0qtYCvyqLropFZqgI2EQw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.81.5"
       },
@@ -6610,17 +7363,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.2.2"
-      }
-    },
     "node_modules/@types/secp256k1": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.7.tgz",
@@ -6724,6 +7466,7 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -7389,6 +8132,7 @@
       "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-2.22.1.tgz",
       "integrity": "sha512-cG/xwQWsBEcKgRTkQVhH29cbpbs/TdcUJVFXCyri3ZknxhMyGv0YEjTcrNpRgt2SaswL1KrvslSNYKKo+5YEAg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eventemitter3": "5.0.1",
         "mipd": "0.0.7",
@@ -8558,6 +9302,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -9345,31 +10090,39 @@
       }
     },
     "node_modules/@walletconnect/utils": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.23.1.tgz",
-      "integrity": "sha512-J12DadZHIL0KvsUoQuK0rag9jDUy8qu1zwz47xEHl03LrMcgrotQiXvdTQ3uHwAVA4yKLTQB/LEI2JiTIt7X8Q==",
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.23.7.tgz",
+      "integrity": "sha512-3p38gNrkVcIiQixVrlsWSa66Gjs5PqHOug2TxDgYUVBW5NcKjwQA08GkC6CKBQUfr5iaCtbfy6uZJW1LKSIvWQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@msgpack/msgpack": "3.1.2",
+        "@msgpack/msgpack": "3.1.3",
         "@noble/ciphers": "1.3.0",
         "@noble/curves": "1.9.7",
         "@noble/hashes": "1.8.0",
         "@scure/base": "1.2.6",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/logger": "3.0.1",
+        "@walletconnect/logger": "3.0.2",
         "@walletconnect/relay-api": "1.0.11",
         "@walletconnect/relay-auth": "1.1.0",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.23.1",
+        "@walletconnect/types": "2.23.7",
         "@walletconnect/window-getters": "1.0.1",
         "@walletconnect/window-metadata": "1.0.1",
         "blakejs": "1.2.1",
-        "bs58": "6.0.0",
         "detect-browser": "5.3.0",
         "ox": "0.9.3",
         "uint8arrays": "3.1.1"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/@msgpack/msgpack": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
+      "integrity": "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@walletconnect/utils/node_modules/@noble/curves": {
@@ -9408,10 +10161,37 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@walletconnect/utils/node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@walletconnect/utils/node_modules/@walletconnect/logger": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.1.tgz",
-      "integrity": "sha512-O8lXGMZO1+e5NtHhBSjsAih/I9KC+1BxNhGNGD+SIWTqWd0zsbT5wJtNnJ+LnSXTRE7XZRxFUlvZgkER3vlhFA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.2.tgz",
+      "integrity": "sha512-7wR3wAwJTOmX4gbcUZcFMov8fjftY05+5cO/d4cpDD8wDzJ+cIlKdYOXaXfxHLSYeDazMXIsxMYjHYVDfkx+nA==",
       "license": "MIT",
       "dependencies": {
         "@walletconnect/safe-json": "^1.0.2",
@@ -9419,17 +10199,62 @@
       }
     },
     "node_modules/@walletconnect/utils/node_modules/@walletconnect/types": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.1.tgz",
-      "integrity": "sha512-sbWOM9oCuzSbz/187rKWnSB3sy7FCFcbTQYeIJMc9+HTMTG2TUPftPCn8NnkfvmXbIeyLw00Y0KNvXoCV/eIeQ==",
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.7.tgz",
+      "integrity": "sha512-6PAKK+iR2IntmlkCFLMAHjYeIaerCJJYRDmdRimhon0u+aNmQT+HyGM6zxDAth0rdpBD7qEvKP5IXZTE7KFUhw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-types": "1.0.4",
         "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/logger": "3.0.1",
+        "@walletconnect/logger": "3.0.2",
         "events": "3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/ox": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.9.3.tgz",
+      "integrity": "sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.0.9",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/ox/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@walletconnect/window-getters": {
@@ -9550,6 +10375,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9566,6 +10392,12 @@
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
+    },
+    "node_modules/aes-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
+      "license": "MIT"
     },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
@@ -9584,6 +10416,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -9621,7 +10454,6 @@
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
       "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -9785,6 +10617,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
       "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -9915,7 +10748,6 @@
       "integrity": "sha512-9KtaCazHee2xc0ibfqsDeamwDps6FZNo5S0Q81dUqEuFzVwPhcT4J5jOqIVvgCA3Q/wO9hKYxN/Ds3tIsp5ygg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "find-babel-config": "^2.1.1",
         "glob": "^9.3.3",
@@ -9930,7 +10762,6 @@
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -9942,7 +10773,6 @@
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "minimatch": "^8.0.2",
@@ -9962,7 +10792,6 @@
       "integrity": "sha512-85MramurFFFSes0exAhJjto4tC4MpGWoktMZl+GYYBPwdpITzZmTKDJDrxhzg2bOyXGIPxlWvGl39tCcQBkuKA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -10059,6 +10888,12 @@
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
       }
+    },
+    "node_modules/bech32": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
+      "license": "MIT"
     },
     "node_modules/big.js": {
       "version": "6.2.2",
@@ -10202,6 +11037,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -10353,7 +11189,6 @@
       "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.3.tgz",
       "integrity": "sha512-750hTRvgBy5kcMNPdh95Qo+XUBeGo8C7nsKSmedDmaQI+E0r82DwHeM6vBewDe4rGFbnxoa4V9pw+sPh5+Iz8Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^5.0.0",
         "confbox": "^0.2.2",
@@ -10535,7 +11370,6 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^5.0.0"
       },
@@ -10572,7 +11406,6 @@
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
       "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "consola": "^3.2.3"
       }
@@ -10661,7 +11494,6 @@
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "color-support": "bin.js"
       }
@@ -10695,15 +11527,13 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
       "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/consola": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
       "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
       }
@@ -11146,7 +11976,6 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
       "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11185,6 +12014,7 @@
       "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.17.tgz",
       "integrity": "sha512-TOOURki4G7sD1wDCjj7NfLaXZZ49dFOeEb5y39IXpb8p0hRzVvfvzZHOi5JcT+PpyAbi/Y+lxPb8eTag2WYH8w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ecies/ciphers": "^0.2.5",
         "@noble/ciphers": "^1.3.0",
@@ -11477,6 +12307,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -11691,6 +12522,7 @@
       "deprecated": "Please migrate to the brand new `eslint-plugin-import-x` instead",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.3.4",
         "doctrine": "^3.0.0",
@@ -12147,6 +12979,55 @@
         "setimmediate": "^1.0.5"
       }
     },
+    "node_modules/ethers": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.8.0.tgz",
+      "integrity": "sha512-DUq+7fHrCg1aPDFCHx6UIPb3nmt2XMpM7Y/g2gLhsl3lIBqeAfOJIl1qEvRf2uq3BiKxmh6Fh5pfp2ieyek7Kg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/abi": "5.8.0",
+        "@ethersproject/abstract-provider": "5.8.0",
+        "@ethersproject/abstract-signer": "5.8.0",
+        "@ethersproject/address": "5.8.0",
+        "@ethersproject/base64": "5.8.0",
+        "@ethersproject/basex": "5.8.0",
+        "@ethersproject/bignumber": "5.8.0",
+        "@ethersproject/bytes": "5.8.0",
+        "@ethersproject/constants": "5.8.0",
+        "@ethersproject/contracts": "5.8.0",
+        "@ethersproject/hash": "5.8.0",
+        "@ethersproject/hdnode": "5.8.0",
+        "@ethersproject/json-wallets": "5.8.0",
+        "@ethersproject/keccak256": "5.8.0",
+        "@ethersproject/logger": "5.8.0",
+        "@ethersproject/networks": "5.8.0",
+        "@ethersproject/pbkdf2": "5.8.0",
+        "@ethersproject/properties": "5.8.0",
+        "@ethersproject/providers": "5.8.0",
+        "@ethersproject/random": "5.8.0",
+        "@ethersproject/rlp": "5.8.0",
+        "@ethersproject/sha2": "5.8.0",
+        "@ethersproject/signing-key": "5.8.0",
+        "@ethersproject/solidity": "5.8.0",
+        "@ethersproject/strings": "5.8.0",
+        "@ethersproject/transactions": "5.8.0",
+        "@ethersproject/units": "5.8.0",
+        "@ethersproject/wallet": "5.8.0",
+        "@ethersproject/web": "5.8.0",
+        "@ethersproject/wordlists": "5.8.0"
+      }
+    },
     "node_modules/ethjs-unit": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
@@ -12181,7 +13062,8 @@
       "version": "6.4.9",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
       "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
@@ -12262,8 +13144,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
       "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ext": {
       "version": "1.7.0",
@@ -12462,7 +13343,6 @@
       "integrity": "sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "json5": "^2.2.3"
       }
@@ -12739,7 +13619,6 @@
       "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
       "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "citty": "^0.1.6",
         "consola": "^3.4.0",
@@ -13121,7 +14000,8 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
       "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -13426,7 +14306,6 @@
       "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
       "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -13731,6 +14610,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -14397,7 +15277,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -14632,6 +15511,7 @@
       "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
       "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "lie": "3.1.1"
       }
@@ -14934,7 +15814,6 @@
       "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -15124,7 +16003,6 @@
       "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
       "integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "citty": "^0.2.0",
         "pathe": "^2.0.3",
@@ -15141,8 +16019,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.1.tgz",
       "integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/obj-multiplex": {
       "version": "1.0.0",
@@ -15218,8 +16095,7 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
@@ -15392,9 +16268,9 @@
       }
     },
     "node_modules/ox": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.9.3.tgz",
-      "integrity": "sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg==",
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.5.tgz",
+      "integrity": "sha512-HgmHmBveYO40H/R3K6TMrwYtHsx/u6TAB+GpZlgJCoW0Sq5Ttpjih0IZZiwGQw7T6vdW4IAyobYrE2mdAvyF8Q==",
       "funding": [
         {
           "type": "github",
@@ -15409,7 +16285,7 @@
         "@noble/hashes": "^1.8.0",
         "@scure/bip32": "^1.7.0",
         "@scure/bip39": "^1.6.0",
-        "abitype": "^1.0.9",
+        "abitype": "^1.2.3",
         "eventemitter3": "5.0.1"
       },
       "peerDependencies": {
@@ -15601,7 +16477,6 @@
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
-      "peer": true,
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -15618,8 +16493,7 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/path-scurry/node_modules/minipass": {
       "version": "7.1.3",
@@ -15627,7 +16501,6 @@
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
-      "peer": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -15645,8 +16518,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/pbkdf2": {
       "version": "3.1.5",
@@ -15669,8 +16541,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
       "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -15684,6 +16555,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15821,7 +16693,6 @@
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
       "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
@@ -16096,7 +16967,6 @@
       "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
       "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -16130,6 +17000,7 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -16471,7 +17342,6 @@
       "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
       "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "defu": "^6.1.4",
         "destr": "^2.0.3"
@@ -16581,6 +17451,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -16595,7 +17466,6 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
       "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 20.19.0"
       },
@@ -16648,8 +17518,7 @@
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
       "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -16949,8 +17818,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/scrypt-js": {
       "version": "3.0.1",
@@ -17126,6 +17994,7 @@
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
       "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.4.1",
@@ -17150,9 +18019,9 @@
       }
     },
     "node_modules/sonic-boom": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
-      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
@@ -17937,6 +18806,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.75.tgz",
       "integrity": "sha512-OhpzAmVzabPOL6C3A3gpAifqr9MqihV/Msx3gor2b2kviCgcb+HM9SEOpMWwwNp9MRunWnhtAKUoo0AHhjyPPg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -17976,7 +18846,6 @@
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
       "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18192,6 +19061,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18507,6 +19377,7 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
       "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -18578,6 +19449,7 @@
       "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.13.2.tgz",
       "integrity": "sha512-Qik0o+DSy741TmkqmRfjq+0xpZBXi/Y6+fXZLn0xNF1z/waFMbE3rkivv5Zcf9RrMUp6zswf2J7sbh2KBlba5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "derive-valtio": "0.1.0",
         "proxy-compare": "2.6.0",
@@ -18609,9 +19481,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.44.2",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.44.2.tgz",
-      "integrity": "sha512-nHY872t/T3flLpVsnvQT/89bwbrJwxaL917FDv7Oxy4E5FWIFkokRQOKXG3P+hgl30QYVZxi9o2SUHLnebycxw==",
+      "version": "2.47.5",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.47.5.tgz",
+      "integrity": "sha512-nVrJEQ8GL4JoVIrMBF3wwpTUZun0cpojfnOZ+96GtDWhqxZkVdy6vOEgu+jwfXqfTA/+wrR+YsN9TBQmhDUk0g==",
       "funding": [
         {
           "type": "github",
@@ -18619,6 +19491,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/curves": "1.9.1",
         "@noble/hashes": "1.8.0",
@@ -18626,7 +19499,7 @@
         "@scure/bip39": "1.6.0",
         "abitype": "1.2.3",
         "isows": "1.0.7",
-        "ox": "0.11.3",
+        "ox": "0.14.5",
         "ws": "8.18.3"
       },
       "peerDependencies": {
@@ -18701,36 +19574,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/viem/node_modules/ox": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.11.3.tgz",
-      "integrity": "sha512-1bWYGk/xZel3xro3l8WGg6eq4YEKlaqvyMtVhfMFpbJzK2F6rj4EDRtqDCWVEJMkzcmEi9uW2QxsqELokOlarw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "^1.11.0",
-        "@noble/ciphers": "^1.3.0",
-        "@noble/curves": "1.9.1",
-        "@noble/hashes": "^1.8.0",
-        "@scure/bip32": "^1.7.0",
-        "@scure/bip39": "^1.6.0",
-        "abitype": "^1.2.3",
-        "eventemitter3": "5.0.1"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/viem/node_modules/ws": {
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
@@ -18757,6 +19600,7 @@
       "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-2.19.5.tgz",
       "integrity": "sha512-RQUfKMv6U+EcSNNGiPbdkDtJwtuFxZWLmvDiQmjjBgkuPulUwDJsKhi7gjynzJdsx2yDqhHCXkKsbbfbIsHfcQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@wagmi/connectors": "6.2.0",
         "@wagmi/core": "2.22.1",
@@ -19135,6 +19979,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -19156,7 +20001,6 @@
       "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
       "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-wsl": "^3.1.0",
         "powershell-utils": "^0.1.0"
@@ -19444,6 +20288,7 @@
       "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-2.3.0.tgz",
       "integrity": "sha512-sb6PgwoW2LjE5oTFu4lhlS/cGt/NB3YrShEyx7JgWFWysfgLdJnhwWThgwy/4HjNsmtMrQGWVls0yVBHcMvlMQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/accounts": "2.3.0",
         "@solana/addresses": "2.3.0",
@@ -19800,6 +20645,7 @@
       "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-2.3.0.tgz",
       "integrity": "sha512-LvjADZrpZ+CnhlHqfI5cmsRzX9Rpyb1Ox2dMHnbsRNzeKAMhu9w4ZBIaeTdO322zsTr509G1B+k2ABD3whvUBA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/accounts": "2.3.0",
         "@solana/codecs": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "@dcl/schemas": "^22.1.0",
     "@magic-ext/oauth2": "15.3.2-canary.1040.22248562051.0",
     "@reown/appkit": "^1.8.15",
+    "@reown/appkit-adapter-ethers5": "^1.8.15",
+    "ethers": "^5.7.2",
     "@web3-react/fortmatic-connector": "^6.1.6",
     "@web3-react/injected-connector": "^6.0.7",
     "@web3-react/network-connector": "^6.1.3",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@magic-ext/oauth2": "15.3.2-canary.1040.22248562051.0",
     "@reown/appkit": "^1.8.15",
     "@reown/appkit-adapter-ethers5": "^1.8.15",
-    "ethers": "^5.7.2",
     "@web3-react/fortmatic-connector": "^6.1.6",
     "@web3-react/injected-connector": "^6.0.7",
     "@web3-react/network-connector": "^6.1.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@dcl/schemas": "^22.1.0",
     "@magic-ext/oauth2": "15.3.2-canary.1040.22248562051.0",
     "@reown/appkit": "^1.8.15",
-    "@reown/appkit-adapter-ethers5": "^1.8.15",
+    "@reown/appkit-adapter-wagmi": "^1.8.19",
     "@web3-react/fortmatic-connector": "^6.1.6",
     "@web3-react/injected-connector": "^6.0.7",
     "@web3-react/network-connector": "^6.1.3",

--- a/src/connectors/WalletConnectV2Connector.ts
+++ b/src/connectors/WalletConnectV2Connector.ts
@@ -126,10 +126,12 @@ export class WalletConnectV2Connector extends AbstractConnector {
     }
 
     const { createAppKit } = await import('@reown/appkit')
+    const { Ethers5Adapter } = await import('@reown/appkit-adapter-ethers5')
 
     const networks = await this.getNetworks()
 
     this.appKit = createAppKit({
+      adapters: [new Ethers5Adapter()],
       projectId: WalletConnectV2Connector.configuration.projectId,
       networks,
       defaultNetwork: networks[0],
@@ -151,7 +153,9 @@ export class WalletConnectV2Connector extends AbstractConnector {
         socials: false,
         onramp: false,
         swaps: false
-      }
+      },
+      enableInjected: true,
+      enableEIP6963: true
     })
 
     // Store for reuse

--- a/src/connectors/WalletConnectV2Connector.ts
+++ b/src/connectors/WalletConnectV2Connector.ts
@@ -126,6 +126,8 @@ export class WalletConnectV2Connector extends AbstractConnector {
     }
 
     const { createAppKit } = await import('@reown/appkit')
+    // Ethers5Adapter enables EIP-6963 wallet discovery for injected wallets (Phantom, MetaMask, etc.).
+    // Without an explicit adapter, AppKit's UniversalAdapter only supports WalletConnect relay connections.
     // eslint-disable-next-line @typescript-eslint/naming-convention
     const { Ethers5Adapter } = await import('@reown/appkit-adapter-ethers5')
 
@@ -156,7 +158,7 @@ export class WalletConnectV2Connector extends AbstractConnector {
         swaps: false
       },
       enableInjected: true,
-      enableEIP6963: true
+      enableEIP6963: true // Default is false — must be explicitly enabled for injected wallet discovery
     })
 
     // Store for reuse

--- a/src/connectors/WalletConnectV2Connector.ts
+++ b/src/connectors/WalletConnectV2Connector.ts
@@ -126,15 +126,21 @@ export class WalletConnectV2Connector extends AbstractConnector {
     }
 
     const { createAppKit } = await import('@reown/appkit')
-    // Ethers5Adapter enables EIP-6963 wallet discovery for injected wallets (Phantom, MetaMask, etc.).
+    // WagmiAdapter enables EIP-6963 wallet discovery for injected wallets (Phantom, MetaMask, etc.).
     // Without an explicit adapter, AppKit's UniversalAdapter only supports WalletConnect relay connections.
+    // wagmi and viem are already transitive deps (via thirdweb and @reown/appkit), so this adds zero bundle weight.
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    const { Ethers5Adapter } = await import('@reown/appkit-adapter-ethers5')
+    const { WagmiAdapter } = await import('@reown/appkit-adapter-wagmi')
 
     const networks = await this.getNetworks()
 
+    const wagmiAdapter = new WagmiAdapter({
+      networks,
+      projectId: WalletConnectV2Connector.configuration.projectId
+    })
+
     this.appKit = createAppKit({
-      adapters: [new Ethers5Adapter()],
+      adapters: [wagmiAdapter],
       projectId: WalletConnectV2Connector.configuration.projectId,
       networks,
       defaultNetwork: networks[0],

--- a/src/connectors/WalletConnectV2Connector.ts
+++ b/src/connectors/WalletConnectV2Connector.ts
@@ -126,6 +126,7 @@ export class WalletConnectV2Connector extends AbstractConnector {
     }
 
     const { createAppKit } = await import('@reown/appkit')
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     const { Ethers5Adapter } = await import('@reown/appkit-adapter-ethers5')
 
     const networks = await this.getNetworks()


### PR DESCRIPTION
## Summary
- Adds `@reown/appkit-adapter-ethers5` to configure AppKit with a real EVM chain adapter that implements EIP-6963 wallet discovery
- Fixes the "Phantom not detected" error when users select Phantom from the WalletConnect modal despite having the browser extension installed
- Explicitly enables `enableInjected` and `enableEIP6963` in the AppKit configuration

## Root Cause
`createAppKit()` was called without any `adapters` property, so AppKit fell back to its built-in `UniversalAdapter` whose `syncConnectors()` is a no-op — it only handles the WalletConnect relay protocol (QR codes/deep links) and never discovers injected browser wallets via EIP-6963.

## Test plan
- [ ] Build succeeds (`npm run build`)
- [ ] All existing tests pass (`npm test`)
- [ ] With Phantom installed: open WalletConnect modal → Phantom shows as "Installed" → clicking it connects directly
- [ ] With MetaMask installed: same flow works for MetaMask
- [ ] QR code flow still works for remote wallets (no injected extension)
- [ ] "Continue with MetaMask" button in auth site still works as before (uses ProviderType.INJECTED, unaffected)

Fixes https://github.com/decentraland/core-team/issues/210