### PR TITLE
fix: Stale connection promise error

### DIFF
--- a/src/ConnectionManager.ts
+++ b/src/ConnectionManager.ts
@@ -99,10 +99,14 @@ export class ConnectionManager {
       }
     }
 
-    const response = this.promiseOfConnection
-      ? await this.promiseOfConnection
-      : await (this.promiseOfConnection = this.connect(connectionData.providerType, connectionData.chainId))
-    this.promiseOfConnection = undefined
+    let response: ConnectionResponse
+    try {
+      response = this.promiseOfConnection
+        ? await this.promiseOfConnection
+        : await (this.promiseOfConnection = this.connect(connectionData.providerType, connectionData.chainId))
+    } finally {
+      this.promiseOfConnection = undefined
+    }
 
     return {
       ...response,


### PR DESCRIPTION
Users with a previous Magic session stored in localStorage who log in via email (Thirdweb) encounter a `"Magic: user isn't logged in"` error, even though the Thirdweb OTP verification succeeds.

### Root cause

In `ConnectionManager.tryPreviousConnection()`, when `this.connect()` rejects, the cleanup line `this.promiseOfConnection = undefined` is never reached because it sits after the `await` that throws:

```ts
// Before fix
const response = this.promiseOfConnection
  ? await this.promiseOfConnection
  : await (this.promiseOfConnection = this.connect(...))
this.promiseOfConnection = undefined  // ← skipped if connect() rejects
```

This leaves a **stale rejected promise** cached in `promiseOfConnection`. Any subsequent call to `tryPreviousConnection()` finds the truthy `promiseOfConnection`, awaits it, and immediately re-throws the original error — even if the stored connection type has since been updated to a different provider.

### Reproduction sequence

1. User has a previous Magic session in localStorage (e.g., from a social login)
2. User visits `/auth/login` — page load calls `tryPreviousConnection()` → attempts `connect(MAGIC)` → MagicConnector throws "user isn't logged in" → **`promiseOfConnection` is set to the rejected promise but never cleared**
3. User completes Thirdweb email OTP → `storeConnectionData(THIRDWEB)` updates localStorage
4. Login flow calls `tryPreviousConnection()` again → finds the stale rejected promise → immediately re-throws "Magic: user isn't logged in"

## The Fix

Wrap the `promiseOfConnection` logic in a `try/finally` block so the promise is **always cleared**, whether `connect()` resolves or rejects:

```ts
let response: ConnectionResponse
try {
  response = this.promiseOfConnection
    ? await this.promiseOfConnection
    : await (this.promiseOfConnection = this.connect(...))
} finally {
  this.promiseOfConnection = undefined
}
```

This ensures that a failed connection attempt never poisons future `tryPreviousConnection` calls. The next call will read the current provider type from storage and attempt a fresh `connect()`.