### PR TITLE
fix: handle metamask mobile and wallet connect in buildconnector

### DIFF
--- a/src/ConnectionManager.ts
+++ b/src/ConnectionManager.ts
@@ -179,7 +179,13 @@ export class ConnectionManager {
         return new WalletLinkConnector(chainId)
       case ProviderType.NETWORK:
         return new NetworkConnector(chainId)
+      case ProviderType.WALLET_CONNECT:
       case ProviderType.WALLET_CONNECT_V2:
+      case ProviderType.METAMASK_MOBILE:
+        // WALLET_CONNECT (v1, deprecated) and METAMASK_MOBILE both resolve to the
+        // WalletConnect v2 connector. METAMASK_MOBILE is surfaced by
+        // getAvailableProviders() on mobile, so it must build a real connector here
+        // instead of falling through to the "Invalid provider" error.
         return new WalletConnectV2Connector(chainId)
       case ProviderType.THIRDWEB:
         // Thirdweb connector for email OTP and social logins

--- a/test/ConnectionManager.spec.ts
+++ b/test/ConnectionManager.spec.ts
@@ -2,7 +2,7 @@ import { ChainId } from '@dcl/schemas/dist/dapps/chain-id'
 import { ProviderType } from '@dcl/schemas/dist/dapps/provider-type'
 import { getConfiguration } from '../src/configuration'
 import { ConnectionManager, connection } from '../src/ConnectionManager'
-import { FortmaticConnector, InjectedConnector, WalletLinkConnector } from '../src/connectors'
+import { FortmaticConnector, InjectedConnector, WalletConnectV2Connector, WalletLinkConnector } from '../src/connectors'
 import { LocalStorage } from '../src/storage'
 import { ClosableConnector, ErrorUnlockingWallet } from '../src/types'
 import { StubClosableConnector, StubConnector, StubLockedWalletConnector, StubStorage, getSendableProvider } from './utils'
@@ -351,6 +351,21 @@ describe('ConnectionManager', () => {
       const connector = connectionManager.buildConnector(ProviderType.WALLET_LINK, chainId)
       expect(connector).toBeInstanceOf(WalletLinkConnector)
       expect(connector.supportedChainIds).toEqual([chainId])
+    })
+
+    it('should return an instance of WalletConnectV2Connector for WALLET_CONNECT_V2', () => {
+      const connector = connectionManager.buildConnector(ProviderType.WALLET_CONNECT_V2, chainId)
+      expect(connector).toBeInstanceOf(WalletConnectV2Connector)
+    })
+
+    it('should return an instance of WalletConnectV2Connector for the deprecated WALLET_CONNECT', () => {
+      const connector = connectionManager.buildConnector(ProviderType.WALLET_CONNECT, chainId)
+      expect(connector).toBeInstanceOf(WalletConnectV2Connector)
+    })
+
+    it('should return an instance of WalletConnectV2Connector for METAMASK_MOBILE', () => {
+      const connector = connectionManager.buildConnector(ProviderType.METAMASK_MOBILE, chainId)
+      expect(connector).toBeInstanceOf(WalletConnectV2Connector)
     })
   })
 })


### PR DESCRIPTION
## Changes

- `buildConnector()` now handles `ProviderType.WALLET_CONNECT` (deprecated v1) and `ProviderType.METAMASK_MOBILE`, routing both to `WalletConnectV2Connector` (same as `WALLET_CONNECT_V2`).
- Add spec coverage asserting all three provider types resolve to the v2 connector.

## Why

`getAvailableProviders()` advertises `METAMASK_MOBILE` on mobile (and `WALLET_CONNECT` always), but `buildConnector()` had no case for either — both fell through to `throw new Error('Invalid provider ...')`. So a direct `connection.connect(ProviderType.METAMASK_MOBILE)` would throw. Today it's masked only because `decentraland-dapps` remaps those to `WALLET_CONNECT_V2` before reaching `connect()`; this removes the latent footgun for any consumer calling `connect()` directly. There is no v1 WalletConnect connector left in the codebase, so v2 is the correct target.

## Test plan

- [x] `npm run lint`, `npm run build`, `npm test` (62 passing)