### PR TITLE
feat: expose getEmail accessor on social connectors

### DIFF
--- a/src/ConnectionManager.ts
+++ b/src/ConnectionManager.ts
@@ -16,7 +16,7 @@ import {
 } from './connectors'
 import { ProviderAdapter } from './ProviderAdapter'
 import { LocalStorage, Storage } from './storage'
-import { ClosableConnector, ConnectionData, ConnectionResponse, Provider } from './types'
+import { ClosableConnector, ConnectionData, ConnectionResponse, EmailConnector, Provider } from './types'
 
 export class ConnectionManager {
   connector?: AbstractConnector
@@ -161,6 +161,24 @@ export class ConnectionManager {
     }
 
     return undefined
+  }
+
+  /**
+   * Obtain the email of the signed-in user, when the active connector exposes one.
+   * Only social/embedded-wallet connectors (Magic, Thirdweb) return a value; every
+   * other connector, and the absence of a connection, resolves to `undefined`.
+   * Never throws — resolves to `undefined` on any error or when unsupported.
+   */
+  async getEmail(): Promise<string | undefined> {
+    const connector = this.connector as Partial<EmailConnector> | undefined
+    if (!connector?.getEmail) {
+      return undefined
+    }
+    try {
+      return await connector.getEmail()
+    } catch (error) {
+      return undefined
+    }
   }
 
   async createProvider(providerType: ProviderType, chainId: ChainId = ChainId.ETHEREUM_MAINNET): Promise<Provider> {

--- a/src/connectors/MagicConnector.ts
+++ b/src/connectors/MagicConnector.ts
@@ -95,6 +95,22 @@ export class MagicConnector extends AbstractConnector {
     return this.account
   }
 
+  getEmail = async (): Promise<string | undefined> => {
+    try {
+      if (!this.magic) {
+        return undefined
+      }
+      const isLoggedIn = await this.magic.user.isLoggedIn()
+      if (!isLoggedIn) {
+        return undefined
+      }
+      const info = await this.magic.user.getInfo()
+      return info?.email ?? undefined
+    } catch (error) {
+      return undefined
+    }
+  }
+
   public close(): Promise<boolean> {
     if (!this.magic) {
       throw new Error('Magic: instance was not initialized')

--- a/src/connectors/ThirdwebConnector.ts
+++ b/src/connectors/ThirdwebConnector.ts
@@ -237,6 +237,27 @@ export class ThirdwebConnector extends AbstractConnector {
   }
 
   /**
+   * Get the email of the authenticated in-app wallet user, if any.
+   *
+   * Uses thirdweb's `getUserEmail({ client })` from `thirdweb/wallets/in-app`.
+   * Resolves to `undefined` when the user is not authenticated, has no email
+   * (e.g. social logins without an email), or thirdweb is unavailable.
+   * Never throws.
+   *
+   * @see https://portal.thirdweb.com/references/typescript/v5/getUserEmail
+   */
+  getEmail = async (): Promise<string | undefined> => {
+    try {
+      const client = await this.getClient()
+      const { getUserEmail } = await import('thirdweb/wallets/in-app')
+      const email = await getUserEmail({ client })
+      return email ?? undefined
+    } catch (error) {
+      return undefined
+    }
+  }
+
+  /**
    * Close/disconnect the wallet
    */
   public async close(): Promise<void> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,10 @@ export interface ClosableConnector extends AbstractConnector {
   close: () => Promise<void>
 }
 
+export interface EmailConnector extends AbstractConnector {
+  getEmail: () => Promise<string | undefined>
+}
+
 export class ErrorUnlockingWallet extends Error {
   constructor() {
     super('There was an error unlocking your wallet. Please be sure your wallet is unlocked and try again.')

--- a/test/ConnectionManager.spec.ts
+++ b/test/ConnectionManager.spec.ts
@@ -293,6 +293,35 @@ describe('ConnectionManager', () => {
     })
   })
 
+  describe('#getEmail', () => {
+    it('should return undefined if no connector is set', async () => {
+      connectionManager.connector = undefined
+      await expect(connectionManager.getEmail()).resolves.toBeUndefined()
+    })
+
+    it('should return undefined if the connector does not expose getEmail', async () => {
+      connectionManager.connector = new StubConnector()
+      await expect(connectionManager.getEmail()).resolves.toBeUndefined()
+    })
+
+    it('should delegate to the connector getEmail when available', async () => {
+      const stubConnector = new StubConnector() as StubConnector & { getEmail: () => Promise<string | undefined> }
+      stubConnector.getEmail = jest.fn().mockResolvedValue('user@example.com')
+      connectionManager.connector = stubConnector
+
+      await expect(connectionManager.getEmail()).resolves.toBe('user@example.com')
+      expect(stubConnector.getEmail).toHaveBeenCalledTimes(1)
+    })
+
+    it('should resolve to undefined if the connector getEmail throws', async () => {
+      const stubConnector = new StubConnector() as StubConnector & { getEmail: () => Promise<string | undefined> }
+      stubConnector.getEmail = jest.fn().mockRejectedValue(new Error('boom'))
+      connectionManager.connector = stubConnector
+
+      await expect(connectionManager.getEmail()).resolves.toBeUndefined()
+    })
+  })
+
   describe('#getAvailableProviders', () => {
     it('should return an array with the provider types', () => {
       expect(connectionManager.getAvailableProviders()).toEqual([

--- a/test/MagicConnector.spec.ts
+++ b/test/MagicConnector.spec.ts
@@ -1,0 +1,80 @@
+import { ChainId } from '@dcl/schemas/dist/dapps/chain-id'
+import { MagicConnector } from '../src/connectors/MagicConnector'
+
+describe('MagicConnector', () => {
+  let connector: MagicConnector
+  let isLoggedIn: jest.Mock
+  let getInfo: jest.Mock
+
+  beforeEach(() => {
+    connector = new MagicConnector(ChainId.ETHEREUM_MAINNET)
+    isLoggedIn = jest.fn()
+    getInfo = jest.fn()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('when getting the email', () => {
+    describe('and the magic instance is not initialized', () => {
+      it('should return undefined', async () => {
+        const email = await connector.getEmail()
+        expect(email).toBeUndefined()
+      })
+    })
+
+    describe('and the magic instance is initialized', () => {
+      beforeEach(() => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ;(connector as any).magic = { user: { isLoggedIn, getInfo } }
+      })
+
+      describe('and the user is not logged in', () => {
+        beforeEach(() => {
+          isLoggedIn.mockResolvedValueOnce(false)
+        })
+
+        it('should return undefined without calling getInfo', async () => {
+          const email = await connector.getEmail()
+          expect(email).toBeUndefined()
+          expect(getInfo).not.toHaveBeenCalled()
+        })
+      })
+
+      describe('and the user is logged in with an email', () => {
+        beforeEach(() => {
+          isLoggedIn.mockResolvedValueOnce(true)
+          getInfo.mockResolvedValueOnce({ email: 'user@example.com' })
+        })
+
+        it('should return the email', async () => {
+          const email = await connector.getEmail()
+          expect(email).toBe('user@example.com')
+        })
+      })
+
+      describe('and the user is logged in without an email', () => {
+        beforeEach(() => {
+          isLoggedIn.mockResolvedValueOnce(true)
+          getInfo.mockResolvedValueOnce({ email: null })
+        })
+
+        it('should return undefined', async () => {
+          const email = await connector.getEmail()
+          expect(email).toBeUndefined()
+        })
+      })
+
+      describe('and reading the user info throws', () => {
+        beforeEach(() => {
+          isLoggedIn.mockRejectedValueOnce(new Error('boom'))
+        })
+
+        it('should resolve to undefined without throwing', async () => {
+          await expect(connector.getEmail()).resolves.toBeUndefined()
+        })
+      })
+    })
+  })
+})

--- a/test/ThirdwebConnector.spec.ts
+++ b/test/ThirdwebConnector.spec.ts
@@ -9,6 +9,7 @@ const mockInAppWallet = jest.fn()
 const mockDefineChain = jest.fn()
 const mockToProvider = jest.fn()
 const mockCreateThirdwebClient = jest.fn()
+const mockGetUserEmail = jest.fn()
 
 jest.mock(
   'thirdweb',
@@ -42,6 +43,14 @@ jest.mock(
   'thirdweb/chains',
   () => ({
     defineChain: (chainId: number) => mockDefineChain(chainId)
+  }),
+  { virtual: true }
+)
+
+jest.mock(
+  'thirdweb/wallets/in-app',
+  () => ({
+    getUserEmail: (options: unknown) => mockGetUserEmail(options)
   }),
   { virtual: true }
 )
@@ -162,6 +171,50 @@ describe('ThirdwebConnector', () => {
       it('should return null', async () => {
         const account = await connector.getAccount()
         expect(account).toBeNull()
+      })
+    })
+  })
+
+  describe('when getting the email', () => {
+    beforeEach(() => {
+      connector = new ThirdwebConnector(ChainId.ETHEREUM_MAINNET)
+      mockCreateThirdwebClient.mockReturnValue({ clientId: 'test' })
+    })
+
+    describe('and the user has an email', () => {
+      beforeEach(() => {
+        mockGetUserEmail.mockResolvedValueOnce('user@example.com')
+      })
+
+      it('should return the email', async () => {
+        const email = await connector.getEmail()
+        expect(email).toBe('user@example.com')
+      })
+
+      it('should call getUserEmail with the client', async () => {
+        await connector.getEmail()
+        expect(mockGetUserEmail).toHaveBeenCalledWith(expect.objectContaining({ client: expect.anything() }))
+      })
+    })
+
+    describe('and the user has no email', () => {
+      beforeEach(() => {
+        mockGetUserEmail.mockResolvedValueOnce(undefined)
+      })
+
+      it('should return undefined', async () => {
+        const email = await connector.getEmail()
+        expect(email).toBeUndefined()
+      })
+    })
+
+    describe('and getUserEmail throws', () => {
+      beforeEach(() => {
+        mockGetUserEmail.mockRejectedValueOnce(new Error('boom'))
+      })
+
+      it('should resolve to undefined without throwing', async () => {
+        await expect(connector.getEmail()).resolves.toBeUndefined()
       })
     })
   })


### PR DESCRIPTION
## Changes

- Add `getEmail(): Promise<string | undefined>` to `MagicConnector` (reads `magic.user.getInfo().email`, guarded by `isLoggedIn()`).
- Add `getEmail(): Promise<string | undefined>` to `ThirdwebConnector` (uses `getUserEmail({ client })` from `thirdweb/wallets/in-app`, loaded via the existing dynamic-import pattern).
- Surface it through `ConnectionManager.getEmail()`, which delegates to the active connector when it implements the new `EmailConnector` interface and otherwise resolves to `undefined`.
- Export the `EmailConnector` interface as part of the public API.

Purely additive: no existing connect/disconnect/getProvider behavior changes, and no new dependencies (thirdweb and magic-sdk are already present and loaded dynamically). `getEmail` never throws — it resolves to `undefined` on error, when the user is not logged in, when there is no email (e.g. social logins), and for connectors that do not support email (Injected/MetaMask, WalletConnect, WalletLink, Fortmatic, Network).

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test` (72 passing) — new unit coverage for `MagicConnector.getEmail`, `ThirdwebConnector.getEmail`, and `ConnectionManager.getEmail` (supported, unsupported, not-logged-in, no-email, and error paths)